### PR TITLE
Fix unmatched closing braces at end of plugin file

### DIFF
--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -1085,21 +1085,6 @@ $wpdb->insert($analytics_table, array(
     }
 }
 
-
-
-
-}
-
-
-
-
-}
-
-
-
-
-}
-
 // Plugin Update Checker laden (GitHub) - optional
 require_once NEWS_TICKER_PATH . 'includes/plugin-update-checker/plugin-update-checker.php';
 use YahnisElsts\PluginUpdateChecker\v5\PucFactory;


### PR DESCRIPTION
## Summary
- remove the redundant closing braces at the end of `yadore-monetizer.php`
- ensure the plugin class closes cleanly before loading the update checker

## Testing
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68d00a3c38b48325b4d7f54f591f5fd3