### PR TITLE
Add Gemini 2.0 support and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Yadore Monetizer Pro v2.7.0 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.8.0 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.7.0 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.8.0 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
-✅ **AI Content Analysis** - Gemini AI Integration mit intelligenter Keyword-Erkennung  
+✅ **AI Content Analysis** - Gemini 2.0 & 1.5 Model Support mit intelligenter Keyword-Erkennung
 ✅ **Advanced Analytics** - Umfassende Performance-Berichte und Statistiken  
 ✅ **Bulk Post Scanner** - Automatische Content-Analyse für alle Posts  
 ✅ **Product Overlay System** - Intelligente Produktempfehlungen mit Overlay  
@@ -60,7 +60,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.7.0:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.8.0:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -258,7 +258,12 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.7.0 - VOLLSTÄNDIGE FUNKTIONALITÄT WIEDERHERGESTELLT!**
+## 🎉 **v2.8.0 - GEMINI 2.0 READY RELEASE!**
+
+### **Neue Highlights in v2.8.0:**
+- 🔐 Gespeicherte Gemini API Keys bleiben erhalten, solange sie nicht aktiv entfernt werden
+- 🤖 Vollständige Unterstützung der aktuellen Gemini 2.0 Flash/Pro-Modelle inklusive Flash Lite & 1.5 Flash 8B
+- ⚙️ Live-Gemini-Requests direkt im Plugin mit verbessertem Fehler-Handling
 
 **Alle Features sind wieder verfügbar und voll funktional!**
 
@@ -274,11 +279,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING  
 ✅ **Tools:** COMPREHENSIVE UTILITIES  
 
-**Yadore Monetizer Pro v2.7.0 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.8.0 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.7.0** - Complete Feature Set Release  
+**Current Version: 2.8.0** - Gemini 2.0 Ready Release
 **Feature Status: ✅ ALL INTEGRATED**  
 **WordPress Integration: ✅ 100% COMPLETE**  
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.7 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.8 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: '2.7.0',
+        version: '2.8.0',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.7 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.8 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: '2.7.0',
+        version: '2.8.0',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -1,8 +1,23 @@
+<?php
+$available_models = isset($gemini_models) && is_array($gemini_models) ? $gemini_models : array(
+    'gemini-2.0-flash' => array('label' => 'Gemini 2.0 Flash - Fastest'),
+    'gemini-2.0-flash-lite' => array('label' => 'Gemini 2.0 Flash Lite - Efficient'),
+    'gemini-2.0-pro-exp' => array('label' => 'Gemini 2.0 Pro (Experimental) - Highest quality'),
+    'gemini-2.0-flash-exp' => array('label' => 'Gemini 2.0 Flash (Experimental) - Latest features'),
+    'gemini-1.5-pro' => array('label' => 'Gemini 1.5 Pro - Most capable'),
+    'gemini-1.5-flash' => array('label' => 'Gemini 1.5 Flash - Balanced'),
+    'gemini-1.5-flash-8b' => array('label' => 'Gemini 1.5 Flash 8B - Lightweight'),
+);
+$current_model = isset($selected_gemini_model)
+    ? $selected_gemini_model
+    : get_option('yadore_gemini_model', 'gemini-2.0-flash');
+$current_model_label = $available_models[$current_model]['label'] ?? $current_model;
+?>
 <div class="wrap yadore-admin-wrap">
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.7.0</span>
+        <span class="version-badge">v2.8.0</span>
     </h1>
 
     <div class="yadore-ai-container">
@@ -81,7 +96,7 @@
                                 <div class="config-group">
                                     <label>Current Model</label>
                                     <div class="model-display">
-                                        <span class="model-name"><?php echo get_option('yadore_gemini_model', 'gemini-2.0-flash-exp'); ?></span>
+                                        <span class="model-name"><?php echo esc_html($current_model_label); ?></span>
                                         <span class="model-status active">Active</span>
                                     </div>
                                 </div>
@@ -107,7 +122,7 @@
                                 <h3><span class="dashicons dashicons-performance"></span> Model Performance Comparison</h3>
                                 <div class="performance-grid">
                                     <div class="performance-card">
-                                        <h4>Gemini 2.0 Flash (Experimental)</h4>
+                                        <h4>Gemini 2.0 Flash</h4>
                                         <div class="performance-metrics">
                                             <div class="metric">
                                                 <span class="metric-label">Speed</span>
@@ -118,37 +133,61 @@
                                             <div class="metric">
                                                 <span class="metric-label">Accuracy</span>
                                                 <div class="metric-bar">
-                                                    <div class="metric-fill" style="width: 85%"></div>
+                                                    <div class="metric-fill" style="width: 88%"></div>
                                                 </div>
                                             </div>
                                             <div class="metric">
                                                 <span class="metric-label">Cost</span>
                                                 <div class="metric-bar">
-                                                    <div class="metric-fill" style="width: 20%"></div>
+                                                    <div class="metric-fill" style="width: 25%"></div>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
 
                                     <div class="performance-card">
-                                        <h4>Gemini 1.5 Pro</h4>
+                                        <h4>Gemini 2.0 Pro (Experimental)</h4>
                                         <div class="performance-metrics">
                                             <div class="metric">
                                                 <span class="metric-label">Speed</span>
                                                 <div class="metric-bar">
-                                                    <div class="metric-fill" style="width: 60%"></div>
+                                                    <div class="metric-fill" style="width: 75%"></div>
                                                 </div>
                                             </div>
                                             <div class="metric">
                                                 <span class="metric-label">Accuracy</span>
                                                 <div class="metric-bar">
-                                                    <div class="metric-fill" style="width: 98%"></div>
+                                                    <div class="metric-fill" style="width: 99%"></div>
                                                 </div>
                                             </div>
                                             <div class="metric">
                                                 <span class="metric-label">Cost</span>
                                                 <div class="metric-bar">
+                                                    <div class="metric-fill" style="width: 80%"></div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div class="performance-card">
+                                        <h4>Gemini 1.5 Flash 8B</h4>
+                                        <div class="performance-metrics">
+                                            <div class="metric">
+                                                <span class="metric-label">Speed</span>
+                                                <div class="metric-bar">
+                                                    <div class="metric-fill" style="width: 85%"></div>
+                                                </div>
+                                            </div>
+                                            <div class="metric">
+                                                <span class="metric-label">Accuracy</span>
+                                                <div class="metric-bar">
                                                     <div class="metric-fill" style="width: 70%"></div>
+                                                </div>
+                                            </div>
+                                            <div class="metric">
+                                                <span class="metric-label">Cost</span>
+                                                <div class="metric-bar">
+                                                    <div class="metric-fill" style="width: 15%"></div>
                                                 </div>
                                             </div>
                                         </div>

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.7.0</span>
+        <span class="version-badge">v2.8.0</span>
     </h1>
 
     <div class="yadore-analytics-container">

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.7.0</span>
+        <span class="version-badge">v2.8.0</span>
     </h1>
 
     <div class="yadore-api-container">
@@ -219,7 +219,7 @@
                                 <div class="endpoint-details">
                                     <div class="endpoint-url">
                                         <span class="method">POST</span>
-                                        <code>https://generativelanguage.googleapis.com/v1/models/{model}:generateContent</code>
+                                        <code>https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent</code>
                                     </div>
 
                                     <div class="endpoint-description">
@@ -230,19 +230,29 @@
                                         <h4>Available Models</h4>
                                         <div class="models-list">
                                             <div class="model-item">
-                                                <h5>gemini-2.0-flash-exp</h5>
-                                                <p>Experimental model with fastest response times</p>
+                                                <h5>gemini-2.0-flash</h5>
+                                                <p>Fastest real-time model for production workloads</p>
                                                 <span class="model-badge recommended">Recommended</span>
                                             </div>
                                             <div class="model-item">
-                                                <h5>gemini-1.5-pro</h5>
-                                                <p>Most capable model with highest accuracy</p>
+                                                <h5>gemini-2.0-pro-exp</h5>
+                                                <p>Experimental pro model with the highest reasoning quality</p>
                                                 <span class="model-badge premium">Premium</span>
                                             </div>
                                             <div class="model-item">
-                                                <h5>gemini-1.5-flash</h5>
-                                                <p>Balanced performance and speed</p>
-                                                <span class="model-badge standard">Standard</span>
+                                                <h5>gemini-2.0-flash-lite</h5>
+                                                <p>Cost-efficient 2.0 model optimized for automation tasks</p>
+                                                <span class="model-badge standard">Efficient</span>
+                                            </div>
+                                            <div class="model-item">
+                                                <h5>gemini-1.5-flash-8b</h5>
+                                                <p>Lightweight option for quick content tagging and metadata</p>
+                                                <span class="model-badge standard">Lightweight</span>
+                                            </div>
+                                            <div class="model-item">
+                                                <h5>gemini-1.5-pro</h5>
+                                                <p>Highest accuracy for long-form editorial analysis</p>
+                                                <span class="model-badge premium">Advanced</span>
                                             </div>
                                         </div>
                                     </div>

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.7.0</span>
+        <span class="version-badge">v2.8.0</span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.7.0</span>
+                            <span class="info-value version-current">v2.8.0</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.7.0</span>
+        <span class="version-badge">v2.8.0</span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.7.0</span>
+                                    <span class="info-value">2.8.0</span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.7.0</span>
+        <span class="version-badge">v2.8.0</span>
     </h1>
 
     <div class="yadore-scanner-container">

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.7.0</span>
+        <span class="version-badge">v2.8.0</span>
     </h1>
 
     <?php
@@ -142,19 +142,37 @@
                                     <span class="required">*</span>
                                 </label>
                                 <div class="input-group">
-                                    <input type="password" 
-                                           name="yadore_gemini_api_key" 
+                                    <input type="password"
+                                           name="yadore_gemini_api_key"
                                            id="yadore_gemini_api_key"
-                                           value="<?php echo esc_attr(get_option('yadore_gemini_api_key', '')); ?>" 
+                                           value="<?php echo esc_attr(get_option('yadore_gemini_api_key', '')); ?>"
                                            class="form-input"
-                                           placeholder="Enter your Gemini API key">
+                                           placeholder="Enter your Gemini API key"
+                                           autocomplete="new-password">
                                     <button type="button" class="button button-secondary" id="test-gemini-api">
                                         <span class="dashicons dashicons-admin-generic"></span> Test AI
                                     </button>
                                 </div>
                                 <p class="form-description">
-                                    Get your free Gemini API key from 
+                                    Get your free Gemini API key from
                                     <a href="https://makersuite.google.com/app/apikey" target="_blank">Google AI Studio</a>.
+                                </p>
+                                <?php if (get_option('yadore_gemini_api_key')) : ?>
+                                    <p class="form-description">
+                                        <?php esc_html_e('A Gemini API key is currently stored securely. Leave the field blank to keep the existing key.', 'yadore-monetizer'); ?>
+                                    </p>
+                                <?php else : ?>
+                                    <p class="form-description">
+                                        <?php esc_html_e('Enter your Gemini API key and save the settings to activate AI features.', 'yadore-monetizer'); ?>
+                                    </p>
+                                <?php endif; ?>
+                                <p class="form-description form-checkbox-inline">
+                                    <label>
+                                        <input type="checkbox"
+                                               name="yadore_gemini_api_key_remove"
+                                               value="1">
+                                        <?php esc_html_e('Remove the stored key when saving', 'yadore-monetizer'); ?>
+                                    </label>
                                 </p>
                                 <div id="gemini-api-test-results" class="api-test-results"></div>
                             </div>
@@ -164,25 +182,47 @@
                                     <strong>AI Model</strong>
                                 </label>
                                 <div class="model-selection">
+                                    <?php
+                                    $available_models = isset($gemini_models) && is_array($gemini_models) ? $gemini_models : array(
+                                        'gemini-2.0-flash' => array('label' => 'Gemini 2.0 Flash - Fastest'),
+                                        'gemini-2.0-flash-lite' => array('label' => 'Gemini 2.0 Flash Lite - Efficient'),
+                                        'gemini-2.0-pro-exp' => array('label' => 'Gemini 2.0 Pro (Experimental) - Highest quality'),
+                                        'gemini-2.0-flash-exp' => array('label' => 'Gemini 2.0 Flash (Experimental) - Latest features'),
+                                        'gemini-1.5-pro' => array('label' => 'Gemini 1.5 Pro - Most capable'),
+                                        'gemini-1.5-flash' => array('label' => 'Gemini 1.5 Flash - Balanced'),
+                                        'gemini-1.5-flash-8b' => array('label' => 'Gemini 1.5 Flash 8B - Lightweight'),
+                                    );
+                                    $current_model = isset($selected_gemini_model)
+                                        ? $selected_gemini_model
+                                        : get_option('yadore_gemini_model', 'gemini-2.0-flash');
+                                    ?>
                                     <select name="yadore_gemini_model" id="yadore_gemini_model" class="form-select">
-                                        <option value="gemini-2.0-flash-exp" <?php selected(get_option('yadore_gemini_model', 'gemini-2.0-flash-exp'), 'gemini-2.0-flash-exp'); ?>>
-                                            Gemini 2.0 Flash (Experimental) - Fastest
-                                        </option>
-                                        <option value="gemini-1.5-pro" <?php selected(get_option('yadore_gemini_model', ''), 'gemini-1.5-pro'); ?>>
-                                            Gemini 1.5 Pro - Most Capable
-                                        </option>
-                                        <option value="gemini-1.5-flash" <?php selected(get_option('yadore_gemini_model', ''), 'gemini-1.5-flash'); ?>>
-                                            Gemini 1.5 Flash - Balanced
-                                        </option>
+                                        <?php foreach ($available_models as $model_key => $model_info) : ?>
+                                            <option value="<?php echo esc_attr($model_key); ?>" <?php selected($current_model, $model_key); ?>>
+                                                <?php echo esc_html($model_info['label'] ?? $model_key); ?>
+                                            </option>
+                                        <?php endforeach; ?>
                                     </select>
+                                    <?php
+                                    $preset_buttons = array(
+                                        'gemini-2.0-flash' => __('Flash 2.0', 'yadore-monetizer'),
+                                        'gemini-2.0-pro-exp' => __('Pro 2.0 (Exp)', 'yadore-monetizer'),
+                                        'gemini-1.5-pro' => __('1.5 Pro', 'yadore-monetizer'),
+                                        'gemini-1.5-flash-8b' => __('1.5 Flash 8B', 'yadore-monetizer'),
+                                    );
+                                    ?>
                                     <div class="model-presets">
-                                        <button type="button" class="button button-small model-preset" data-model="gemini-2.0-flash-exp">Fast</button>
-                                        <button type="button" class="button button-small model-preset" data-model="gemini-1.5-pro">Pro</button>
-                                        <button type="button" class="button button-small model-preset" data-model="gemini-1.5-flash">Balanced</button>
+                                        <?php foreach ($preset_buttons as $model_key => $label) : ?>
+                                            <button type="button"
+                                                    class="button button-small model-preset <?php echo $current_model === $model_key ? 'button-primary' : 'button-secondary'; ?>"
+                                                    data-model="<?php echo esc_attr($model_key); ?>">
+                                                <?php echo esc_html($label); ?>
+                                            </button>
+                                        <?php endforeach; ?>
                                     </div>
                                 </div>
                                 <p class="form-description">
-                                    Choose the AI model that best fits your needs. Flash models are faster, Pro models are more accurate.
+                                    Choose from the latest Gemini models. Gemini 2.0 provides the newest capabilities, while Gemini 1.5 models balance performance and cost.
                                 </p>
                             </div>
 

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.7.0</span>
+        <span class="version-badge">v2.8.0</span>
     </h1>
 
     <div class="yadore-tools-container">


### PR DESCRIPTION
## Summary
- bump the plugin version to 2.8.0 across PHP, assets, templates and documentation
- implement real Gemini API requests with support for the latest Gemini 2.0/1.5 models and improved logging/caching
- keep stored Gemini API keys unless explicitly removed and update the admin UI to manage models and keys

## Testing
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68d0150e808c8325aebcd43cb15289ca