### PR TITLE
Release v2.9.0 with native Yadore API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v2.8.0 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.0 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.8.0 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.0 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
@@ -14,7 +14,15 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **Debug & Error Analysis** - Vollständige Systemdiagnose und Fehlerbehebung  
 ✅ **Data Management Tools** - Export/Import, Backup und Migration  
 ✅ **16 AJAX Endpoints** - Alle korrekt implementiert ohne Konflikte  
-✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support  
+✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
+
+## 🌟 **NEU IN VERSION 2.9.0**
+
+- ✅ **Native Yadore API Integration** – Direkte Anbindung der Endpoint `https://api.yadore.com/products/search` inkl. Caching, Logging und robuster Fehlerbehandlung.
+- ✅ **Intelligente Keyword-Erkennung** – Automatische Ermittlung relevanter Suchbegriffe über gespeicherte Analysen, optionale Gemini-AI-Auswertung und heuristische Fallbacks.
+- ✅ **Optimiertes Frontend** – Entfernte Placeholder-Grafiken, adaptive Platzhalter-Kachel und verbesserte Overlay-Kommunikation mit Post-ID.
+- ✅ **Stabile Overlay-Empfehlungen** – Präzisere Zuordnung der Produktempfehlungen durch Übergabe von Seiten-URL und Beitrag-ID im AJAX-Workflow.
+- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.0 wider.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -60,7 +68,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.8.0:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.0:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -154,7 +162,7 @@ wp_yadore_analytics        - Performance Analytics (NEW)
 - Export/Import Settings
 - Multisite Sync Options
 
-## 📊 **ANALYTICS & REPORTING - NEU IN v2.7:**
+## 📊 **ANALYTICS & REPORTING:**
 
 ### **Performance Metrics:**
 📈 **Product Views** - Detailed view tracking with trends  
@@ -258,9 +266,9 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.8.0 - GEMINI 2.0 READY RELEASE!**
+## 🎉 **v2.9.0 - GEMINI 2.0 READY RELEASE!**
 
-### **Neue Highlights in v2.8.0:**
+### **Neue Highlights in v2.9.0:**
 - 🔐 Gespeicherte Gemini API Keys bleiben erhalten, solange sie nicht aktiv entfernt werden
 - 🤖 Vollständige Unterstützung der aktuellen Gemini 2.0 Flash/Pro-Modelle inklusive Flash Lite & 1.5 Flash 8B
 - ⚙️ Live-Gemini-Requests direkt im Plugin mit verbessertem Fehler-Handling
@@ -279,11 +287,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING  
 ✅ **Tools:** COMPREHENSIVE UTILITIES  
 
-**Yadore Monetizer Pro v2.8.0 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.0 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.8.0** - Gemini 2.0 Ready Release
+**Current Version: 2.9.0** - Gemini 2.0 Ready Release
 **Feature Status: ✅ ALL INTEGRATED**  
 **WordPress Integration: ✅ 100% COMPLETE**  
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.7 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v2.9 - Admin CSS (Complete) */
 .yadore-admin-wrap {
     margin: 0;
 }

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.7 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v2.9 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -26,6 +26,17 @@
     position: relative;
     overflow: hidden;
     aspect-ratio: 16/12;
+}
+
+.yadore-product-image-placeholder {
+    width: 100%;
+    height: 100%;
+    background: #ecf0f1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #95a5a6;
+    font-size: 32px;
 }
 
 .product-image img {
@@ -176,6 +187,11 @@
     overflow: hidden;
 }
 
+.yadore-product-item .yadore-product-image-placeholder {
+    border-radius: 8px;
+    font-size: 28px;
+}
+
 .yadore-product-item .product-image img {
     width: 100%;
     height: 100%;
@@ -292,6 +308,13 @@
     height: 80px;
     object-fit: cover;
     border-radius: 8px;
+}
+
+.inline-image .yadore-product-image-placeholder {
+    width: 80px;
+    height: 80px;
+    border-radius: 8px;
+    font-size: 24px;
 }
 
 .inline-title {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.8 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: '2.8.0',
+        version: '2.9.0',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,
@@ -20,7 +20,7 @@
             this.initTools();
             this.initDebug();
 
-            console.log('Yadore Monetizer Pro v2.7 Admin - Fully Initialized');
+            console.log('Yadore Monetizer Pro v2.9 Admin - Fully Initialized');
         },
 
         // Dashboard functionality

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.8 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: '2.8.0',
+        version: '2.9.0',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,
@@ -25,7 +25,7 @@
             this.initScrollTriggers();
             this.initResponsiveHandling();
 
-            console.log('Yadore Monetizer Pro v2.7 Frontend - Initialized');
+            console.log('Yadore Monetizer Pro v2.9 Frontend - Initialized');
         },
 
         // Initialize product overlay
@@ -145,7 +145,8 @@
                 nonce: this.settings.nonce,
                 limit: this.settings.limit || 3,
                 page_content: pageContent,
-                page_url: window.location.href
+                page_url: window.location.href,
+                post_id: this.settings.post_id || 0
             })
             .done((response) => {
                 if (response.success && response.data.products && response.data.products.length > 0) {
@@ -182,8 +183,8 @@
             const overlayBody = this.overlay.find('.overlay-body');
             let productsHtml = '<div class="overlay-products">';
 
-            products.forEach((product, index) => {
-                const imageUrl = product.thumbnail?.url || product.image?.url || 'https://via.placeholder.com/200x150';
+            products.forEach((product) => {
+                const imageUrl = product.thumbnail?.url || product.image?.url || '';
                 const title = product.title || 'Product';
                 const price = product.price?.amount || 'N/A';
                 const currency = product.price?.currency || '';
@@ -191,10 +192,14 @@
                 const clickUrl = product.clickUrl || '#';
                 const productId = product.id || '';
 
+                const imageMarkup = imageUrl
+                    ? `<img src="${imageUrl}" alt="${title}" loading="lazy">`
+                    : '<div class="overlay-product-image-placeholder" aria-hidden="true">📦</div>';
+
                 productsHtml += `
                     <div class="overlay-product" data-product-id="${productId}">
                         <div class="overlay-product-image">
-                            <img src="${imageUrl}" alt="${title}" loading="lazy">
+                            ${imageMarkup}
                         </div>
                         <div class="overlay-product-content">
                             <h4 class="overlay-product-title">${title}</h4>
@@ -245,6 +250,17 @@
                     width: 100%;
                     height: 150px;
                     object-fit: cover;
+                }
+
+                .overlay-product-image-placeholder {
+                    width: 100%;
+                    height: 150px;
+                    background: #ecf0f1;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    font-size: 32px;
+                    color: #95a5a6;
                 }
 
                 .overlay-product-content {

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -17,7 +17,7 @@ $current_model_label = $available_models[$current_model]['label'] ?? $current_mo
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.8.0</span>
+        <span class="version-badge">v2.9.0</span>
     </h1>
 
     <div class="yadore-ai-container">
@@ -371,7 +371,7 @@ function yadoreInitializeAiManagement() {
     $('#run-ai-test').on('click', yadoreRunAiTest);
     $('#run-batch-test').on('click', yadoreRunBatchTest);
 
-    console.log('Yadore AI Management v2.7 - Initialized');
+    console.log('Yadore AI Management v2.9 - Initialized');
 }
 
 function yadoreLoadAiStats() {

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.8.0</span>
+        <span class="version-badge">v2.9.0</span>
     </h1>
 
     <div class="yadore-analytics-container">
@@ -319,7 +319,7 @@ function yadoreInitializeAnalytics() {
         yadoreLoadPerformanceTable($(this).val());
     });
 
-    console.log('Yadore Analytics v2.7 - Initialized');
+    console.log('Yadore Analytics v2.9 - Initialized');
 }
 
 function yadoreLoadAnalyticsData(period = 30) {

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.8.0</span>
+        <span class="version-badge">v2.9.0</span>
     </h1>
 
     <div class="yadore-api-container">
@@ -409,7 +409,7 @@ function yadoreInitializeApiDocs() {
     $('#clear-logs').on('click', yadoreClearLogs);
     $('#export-logs').on('click', yadoreExportLogs);
 
-    console.log('Yadore API Documentation v2.7 - Initialized');
+    console.log('Yadore API Documentation v2.9 - Initialized');
 }
 
 function yadoreLoadApiStatus() {

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,12 +2,12 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.8.0</span>
+        <span class="version-badge">v2.9.0</span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
     <div class="notice notice-success is-dismissible">
-        <p><strong>Yadore Monetizer Pro v2.7 activated successfully!</strong> All features are now available.</p>
+        <p><strong>Yadore Monetizer Pro v2.9 activated successfully!</strong> All features are now available.</p>
     </div>
     <?php delete_transient('yadore_activation_notice'); endif; ?>
 
@@ -311,7 +311,7 @@
                             <div class="status-indicator status-active"></div>
                             <div class="status-details">
                                 <strong>WordPress Integration</strong>
-                                <small>v2.7 - All systems operational</small>
+                                <small>v2.9 - All systems operational</small>
                             </div>
                         </div>
 
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.8.0</span>
+                            <span class="info-value version-current">v2.9.0</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>
@@ -363,7 +363,7 @@
                         </div>
                         <div class="info-row">
                             <span class="info-label">Database:</span>
-                            <span class="info-value">Enhanced v2.7</span>
+                            <span class="info-value">Enhanced v2.9</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">Features:</span>
@@ -419,7 +419,7 @@ jQuery(document).ready(function($) {
 });
 
 function yadoreInitializeDashboard() {
-    console.log('Yadore Monetizer Pro v2.7 Dashboard - Initialized');
+    console.log('Yadore Monetizer Pro v2.9 Dashboard - Initialized');
 }
 
 function yadoreLoadDashboardStats() {

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.8.0</span>
+        <span class="version-badge">v2.9.0</span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.8.0</span>
+                                    <span class="info-value">2.9.0</span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>
@@ -393,7 +393,7 @@ function yadoreInitializeDebug() {
     $('#auto-scroll').on('change', yadoreToggleAutoScroll);
     $('#word-wrap').on('change', yadoreToggleWordWrap);
 
-    console.log('Yadore Debug System v2.7 - Initialized');
+    console.log('Yadore Debug System v2.9 - Initialized');
 }
 
 function yadoreLoadSystemHealth() {

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.8.0</span>
+        <span class="version-badge">v2.9.0</span>
     </h1>
 
     <div class="yadore-scanner-container">
@@ -321,7 +321,7 @@ function yadoreInitializeScanner() {
     // Results filtering
     $('#results-filter').on('change', yadoreFilterResults);
 
-    console.log('Yadore Post Scanner v2.7 - Initialized');
+    console.log('Yadore Post Scanner v2.9 - Initialized');
 }
 
 function yadoreLoadScannerOverview() {

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.8.0</span>
+        <span class="version-badge">v2.9.0</span>
     </h1>
 
     <?php
@@ -607,7 +607,7 @@ jQuery(document).ready(function($) {
     $('#test-gemini-api').on('click', yadoreTestGeminiApi);
     $('#test-yadore-api').on('click', yadoreTestYadoreApi);
 
-    console.log('Yadore Monetizer Pro v2.7 Settings - Initialized');
+    console.log('Yadore Monetizer Pro v2.9 Settings - Initialized');
 });
 
 function yadoreTestGeminiApi() {

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.8.0</span>
+        <span class="version-badge">v2.9.0</span>
     </h1>
 
     <div class="yadore-tools-container">
@@ -494,7 +494,7 @@ function yadoreInitializeTools() {
         yadoreHandleFileUpload(this.files);
     });
 
-    console.log('Yadore Tools v2.7 - Initialized');
+    console.log('Yadore Tools v2.9 - Initialized');
 }
 
 function yadoreLoadToolStats() {

--- a/templates/products-grid.php
+++ b/templates/products-grid.php
@@ -3,8 +3,15 @@
         <?php foreach ($offers as $offer): ?>
             <div class="yadore-product-card" data-offer-id="<?php echo esc_attr($offer['id'] ?? ''); ?>">
                 <div class="product-image">
-                    <img src="<?php echo esc_url($offer['thumbnail']['url'] ?? $offer['image']['url'] ?? 'https://via.placeholder.com/200x150'); ?>" 
-                         alt="<?php echo esc_attr($offer['title'] ?? 'Product'); ?>" loading="lazy">
+                    <?php
+                    $image_url = $offer['thumbnail']['url'] ?? $offer['image']['url'] ?? '';
+                    if (!empty($image_url)) :
+                    ?>
+                        <img src="<?php echo esc_url($image_url); ?>"
+                             alt="<?php echo esc_attr($offer['title'] ?? 'Product'); ?>" loading="lazy">
+                    <?php else : ?>
+                        <div class="yadore-product-image-placeholder" aria-hidden="true">📦</div>
+                    <?php endif; ?>
 
                     <?php if (!empty($offer['promoText'])): ?>
                         <div class="product-badge"><?php echo esc_html($offer['promoText']); ?></div>

--- a/templates/products-inline.php
+++ b/templates/products-inline.php
@@ -15,8 +15,15 @@
             <?php foreach (array_slice($offers, 0, 3) as $offer): ?>
                 <div class="inline-product" data-offer-id="<?php echo esc_attr($offer['id'] ?? ''); ?>">
                     <div class="inline-image">
-                        <img src="<?php echo esc_url($offer['thumbnail']['url'] ?? $offer['image']['url'] ?? 'https://via.placeholder.com/80x80'); ?>" 
-                             alt="<?php echo esc_attr($offer['title'] ?? 'Product'); ?>" loading="lazy">
+                        <?php
+                        $image_url = $offer['thumbnail']['url'] ?? $offer['image']['url'] ?? '';
+                        if (!empty($image_url)) :
+                        ?>
+                            <img src="<?php echo esc_url($image_url); ?>"
+                                 alt="<?php echo esc_attr($offer['title'] ?? 'Product'); ?>" loading="lazy">
+                        <?php else : ?>
+                            <div class="yadore-product-image-placeholder" aria-hidden="true">📦</div>
+                        <?php endif; ?>
                     </div>
 
                     <div class="inline-details">

--- a/templates/products-list.php
+++ b/templates/products-list.php
@@ -3,8 +3,15 @@
         <?php foreach ($offers as $offer): ?>
             <div class="yadore-product-item" data-offer-id="<?php echo esc_attr($offer['id'] ?? ''); ?>">
                 <div class="product-image">
-                    <img src="<?php echo esc_url($offer['thumbnail']['url'] ?? $offer['image']['url'] ?? 'https://via.placeholder.com/100x100'); ?>" 
-                         alt="<?php echo esc_attr($offer['title'] ?? 'Product'); ?>" loading="lazy">
+                    <?php
+                    $image_url = $offer['thumbnail']['url'] ?? $offer['image']['url'] ?? '';
+                    if (!empty($image_url)) :
+                    ?>
+                        <img src="<?php echo esc_url($image_url); ?>"
+                             alt="<?php echo esc_attr($offer['title'] ?? 'Product'); ?>" loading="lazy">
+                    <?php else : ?>
+                        <div class="yadore-product-image-placeholder" aria-hidden="true">📦</div>
+                    <?php endif; ?>
                 </div>
 
                 <div class="product-details">


### PR DESCRIPTION
## Summary
- bump plugin, documentation, and assets to version 2.9.0
- replace placeholder product generation with real Yadore products/search API integration, including keyword detection heuristics and sanitisation
- refresh frontend templates and styles to remove dummy imagery and improve overlay requests with post context

## Testing
- php -l yadore-monetizer.php
- php -l templates/products-grid.php
- php -l templates/products-list.php
- php -l templates/products-inline.php

------
https://chatgpt.com/codex/tasks/task_e_68d03da5b6608325893c8201d297aa10