### PR TITLE
Bump Yadore Monetizer Pro to 2.9.1 with resilient API test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v2.9.0 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.1 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.9.0 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.1 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
@@ -16,13 +16,14 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **16 AJAX Endpoints** - Alle korrekt implementiert ohne Konflikte  
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 2.9.0**
+## 🌟 **NEU IN VERSION 2.9.1**
 
+- ✅ **Resiliente Yadore API Tests** – Fallback-Demo-Produkte stellen sicher, dass der Verbindungstest nie fehlschlägt, selbst ohne API-Key. Admins erhalten einen klaren Hinweis auf den Fallback-Modus und sehen sofort Beispielprodukte für die Validierung.
 - ✅ **Native Yadore API Integration** – Direkte Anbindung der Endpoint `https://api.yadore.com/products/search` inkl. Caching, Logging und robuster Fehlerbehandlung.
 - ✅ **Intelligente Keyword-Erkennung** – Automatische Ermittlung relevanter Suchbegriffe über gespeicherte Analysen, optionale Gemini-AI-Auswertung und heuristische Fallbacks.
 - ✅ **Optimiertes Frontend** – Entfernte Placeholder-Grafiken, adaptive Platzhalter-Kachel und verbesserte Overlay-Kommunikation mit Post-ID.
 - ✅ **Stabile Overlay-Empfehlungen** – Präzisere Zuordnung der Produktempfehlungen durch Übergabe von Seiten-URL und Beitrag-ID im AJAX-Workflow.
-- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.0 wider.
+- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.1 wider.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -68,7 +69,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.0:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.1:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -266,9 +267,10 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.9.0 - GEMINI 2.0 READY RELEASE!**
+## 🎉 **v2.9.1 - GEMINI 2.0 READY RELEASE!**
 
-### **Neue Highlights in v2.9.0:**
+### **Neue Highlights in v2.9.1:**
+- 🌐 Ausfallsichere Yadore API Tests mit intelligenten Fallback-Daten und klaren Administrator-Hinweisen
 - 🔐 Gespeicherte Gemini API Keys bleiben erhalten, solange sie nicht aktiv entfernt werden
 - 🤖 Vollständige Unterstützung der aktuellen Gemini 2.0 Flash/Pro-Modelle inklusive Flash Lite & 1.5 Flash 8B
 - ⚙️ Live-Gemini-Requests direkt im Plugin mit verbessertem Fehler-Handling
@@ -287,11 +289,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING  
 ✅ **Tools:** COMPREHENSIVE UTILITIES  
 
-**Yadore Monetizer Pro v2.9.0 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.1 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.9.0** - Gemini 2.0 Ready Release
+**Current Version: 2.9.1** - Gemini 2.0 Ready Release
 **Feature Status: ✅ ALL INTEGRATED**  
 **WordPress Integration: ✅ 100% COMPLETE**  
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -4,7 +4,7 @@
 
     // Global variables
     window.yadoreAdmin = {
-        version: '2.9.0',
+        version: '2.9.1',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -4,7 +4,7 @@
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: '2.9.0',
+        version: '2.9.1',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -17,7 +17,7 @@ $current_model_label = $available_models[$current_model]['label'] ?? $current_mo
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.9.0</span>
+        <span class="version-badge">v2.9.1</span>
     </h1>
 
     <div class="yadore-ai-container">

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.9.0</span>
+        <span class="version-badge">v2.9.1</span>
     </h1>
 
     <div class="yadore-analytics-container">

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.9.0</span>
+        <span class="version-badge">v2.9.1</span>
     </h1>
 
     <div class="yadore-api-container">

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.9.0</span>
+        <span class="version-badge">v2.9.1</span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.9.0</span>
+                            <span class="info-value version-current">v2.9.1</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.9.0</span>
+        <span class="version-badge">v2.9.1</span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.9.0</span>
+                                    <span class="info-value">2.9.1</span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.9.0</span>
+        <span class="version-badge">v2.9.1</span>
     </h1>
 
     <div class="yadore-scanner-container">

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.9.0</span>
+        <span class="version-badge">v2.9.1</span>
     </h1>
 
     <?php

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.9.0</span>
+        <span class="version-badge">v2.9.1</span>
     </h1>
 
     <div class="yadore-tools-container">


### PR DESCRIPTION
## Summary
- bump plugin version references to 2.9.1 across the core plugin, admin/front-end assets, templates and documentation
- add fallback product handling so the Yadore API test gracefully succeeds and records whether fallback data was used
- document the 2.9.1 release highlights, including the resilient API test behaviour, in the README

## Testing
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68d044c0f2308325847996ffb4852475