### PR TITLE
Release 2.9.2 with live API integration and structured AI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v2.9.1 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.2 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.9.1 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.2 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
@@ -16,14 +16,14 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **16 AJAX Endpoints** - Alle korrekt implementiert ohne Konflikte  
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 2.9.1**
+## 🌟 **NEU IN VERSION 2.9.2**
 
-- ✅ **Resiliente Yadore API Tests** – Fallback-Demo-Produkte stellen sicher, dass der Verbindungstest nie fehlschlägt, selbst ohne API-Key. Admins erhalten einen klaren Hinweis auf den Fallback-Modus und sehen sofort Beispielprodukte für die Validierung.
-- ✅ **Native Yadore API Integration** – Direkte Anbindung der Endpoint `https://api.yadore.com/products/search` inkl. Caching, Logging und robuster Fehlerbehandlung.
-- ✅ **Intelligente Keyword-Erkennung** – Automatische Ermittlung relevanter Suchbegriffe über gespeicherte Analysen, optionale Gemini-AI-Auswertung und heuristische Fallbacks.
-- ✅ **Optimiertes Frontend** – Entfernte Placeholder-Grafiken, adaptive Platzhalter-Kachel und verbesserte Overlay-Kommunikation mit Post-ID.
-- ✅ **Stabile Overlay-Empfehlungen** – Präzisere Zuordnung der Produktempfehlungen durch Übergabe von Seiten-URL und Beitrag-ID im AJAX-Workflow.
-- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.1 wider.
+- ✅ **Echte Live-Daten** – Entfernt sämtliche Demo- und Placeholder-Produkte. Tests und Shortcodes zeigen ausschließlich Yadore-Ergebnisse, sobald ein API-Key hinterlegt ist.
+- ✅ **Konforme Yadore API-Anbindung** – Authentifizierung über `Authorization: Bearer` & `X-Yadore-Api-Key` gemäß offizieller Publisher-Dokumentation, inklusive robuster Fehlerbehandlung und Logging.
+- ✅ **Gemini Structured Output** – Die AI-Analyse nutzt `responseMimeType` & `responseSchema`, liefert damit reproduzierbare JSON-Ergebnisse mit Keyword & Confidence und kann gecacht werden.
+- ✅ **Verbesserte Admin Notices** – Aktivierungsbestätigung, fehlende API-Keys und kritische Fehler erscheinen direkt im WordPress Backend – ganz ohne Platzhaltertexte.
+- ✅ **Härtete API-Tests & Logs** – Die Test-Endpunkte melden realistische Ergebnisse, protokollieren Keyword, Modus und Latenz und liefern klare Handlungsempfehlungen bei leeren Antworten.
+- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.2 wider.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -69,7 +69,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.1:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.2:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -267,13 +267,13 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.9.1 - GEMINI 2.0 READY RELEASE!**
+## 🎉 **v2.9.2 - GEMINI 2.0 READY RELEASE!**
 
-### **Neue Highlights in v2.9.1:**
-- 🌐 Ausfallsichere Yadore API Tests mit intelligenten Fallback-Daten und klaren Administrator-Hinweisen
-- 🔐 Gespeicherte Gemini API Keys bleiben erhalten, solange sie nicht aktiv entfernt werden
-- 🤖 Vollständige Unterstützung der aktuellen Gemini 2.0 Flash/Pro-Modelle inklusive Flash Lite & 1.5 Flash 8B
-- ⚙️ Live-Gemini-Requests direkt im Plugin mit verbessertem Fehler-Handling
+### **Neue Highlights in v2.9.2:**
+- 🌐 Direkte Live-Verbindung zur Yadore Publisher API mit Bearer-Authentifizierung, Request-Caching und detailliertem Logging.
+- 🤖 Gemini Structured Output mit JSON-Schema liefert reproduzierbare Keywords samt Confidence-Werten.
+- 🛎️ Neue Admin Notices melden Aktivierung, fehlende API Keys und kritische Fehler unmittelbar im Dashboard.
+- 📊 API-Test-Endpunkte reagieren ohne Demo-Daten, dokumentieren Keyword & Status und geben klare Handlungsempfehlungen.
 
 **Alle Features sind wieder verfügbar und voll funktional!**
 
@@ -289,11 +289,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING  
 ✅ **Tools:** COMPREHENSIVE UTILITIES  
 
-**Yadore Monetizer Pro v2.9.1 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.2 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.9.1** - Gemini 2.0 Ready Release
+**Current Version: 2.9.2** - Gemini 2.0 Ready Release
 **Feature Status: ✅ ALL INTEGRATED**  
 **WordPress Integration: ✅ 100% COMPLETE**  
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.2 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: '2.9.1',
+        version: '2.9.2',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,
@@ -20,7 +20,7 @@
             this.initTools();
             this.initDebug();
 
-            console.log('Yadore Monetizer Pro v2.9 Admin - Fully Initialized');
+            console.log('Yadore Monetizer Pro v2.9.2 Admin - Fully Initialized');
         },
 
         // Dashboard functionality

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.2 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: '2.9.1',
+        version: '2.9.2',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,
@@ -25,7 +25,7 @@
             this.initScrollTriggers();
             this.initResponsiveHandling();
 
-            console.log('Yadore Monetizer Pro v2.9 Frontend - Initialized');
+            console.log('Yadore Monetizer Pro v2.9.2 Frontend - Initialized');
         },
 
         // Initialize product overlay

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -17,7 +17,7 @@ $current_model_label = $available_models[$current_model]['label'] ?? $current_mo
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.9.1</span>
+        <span class="version-badge">v2.9.2</span>
     </h1>
 
     <div class="yadore-ai-container">

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.9.1</span>
+        <span class="version-badge">v2.9.2</span>
     </h1>
 
     <div class="yadore-analytics-container">

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.9.1</span>
+        <span class="version-badge">v2.9.2</span>
     </h1>
 
     <div class="yadore-api-container">
@@ -158,8 +158,13 @@
 
                                     <div class="endpoint-example">
                                         <h4>Example Request</h4>
-                                        <pre><code>{
-  "api_key": "your_api_key_here",
+                                        <pre><code>POST /products/search HTTP/1.1
+Host: api.yadore.com
+Authorization: Bearer YOUR_API_KEY
+X-Yadore-Api-Key: YOUR_API_KEY
+Content-Type: application/json
+
+{
   "keyword": "smartphone",
   "limit": 6,
   "country": "US"
@@ -272,6 +277,17 @@
   "generationConfig": {
     "temperature": 0.3,
     "maxOutputTokens": 50
+  },
+  "responseMimeType": "application/json",
+  "responseSchema": {
+    "type": "object",
+    "properties": {
+      "keyword": { "type": "string" },
+      "confidence": { "type": "number" },
+      "rationale": { "type": "string" }
+    },
+    "required": ["keyword"],
+    "additionalProperties": false
   }
 }</code></pre>
                                     </div>

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.9.1</span>
+        <span class="version-badge">v2.9.2</span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.9.1</span>
+                            <span class="info-value version-current">v2.9.2</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.9.1</span>
+        <span class="version-badge">v2.9.2</span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.9.1</span>
+                                    <span class="info-value">2.9.2</span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.9.1</span>
+        <span class="version-badge">v2.9.2</span>
     </h1>
 
     <div class="yadore-scanner-container">

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.9.1</span>
+        <span class="version-badge">v2.9.2</span>
     </h1>
 
     <?php

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.9.1</span>
+        <span class="version-badge">v2.9.2</span>
     </h1>
 
     <div class="yadore-tools-container">


### PR DESCRIPTION
## Summary
- bump plugin, assets, and documentation to version 2.9.2 while refreshing admin version badges
- remove demo fallback data, harden Yadore API calls with bearer authentication headers, and surface detailed admin notices
- switch Gemini AI requests to structured JSON output (responseMimeType/Schema) and adjust consumers plus API documentation examples

## Testing
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68d0597f31948325bc292d5c4ea801eb