### PR TITLE
Release 2.9.4: fix settings persistence and Yadore API compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v2.9.3 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.4 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.9.3 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.4 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
@@ -16,13 +16,13 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **16 AJAX Endpoints** - Alle korrekt implementiert ohne Konflikte  
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 2.9.3**
+## 🌟 **NEU IN VERSION 2.9.4**
 
-- ✅ **Migration auf die Yadore Publisher API 2.0** – Produktabfragen nutzen jetzt `GET https://api.yadore.com/v2/offer` inklusive Header `API-Key`. Die bisherige 404-Fehlermeldung wird vollständig eliminiert.
-- ✅ **Flexible Offer-Verarbeitung** – Neue Response-Parser akzeptieren `offers`, `items` oder verschachtelte `data`-Container und mappen Felder wie `deeplink`, `imageUrl` oder `merchantName` automatisch.
-- ✅ **Aktualisierte Entwickler-Dokumentation** – Das Admin-Panel zeigt die korrekten API-Parameter, Beispiele und Header für die Offer-Endpunkte der Publisher API 2.0.
-- ✅ **Verbesserte Fehlerprotokolle** – API-Logs speichern nun auch die angefragte URL, damit Status- und Payload-Fehler schneller nachvollzogen werden können.
-- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.3 wider.
+- ✅ **Stabile Einstellungen** – Das Settings-Formular nutzt jetzt ein echtes WordPress-Formular und speichert alle Optionen zuverlässig.
+- ✅ **Marktverwaltung nach API-Spezifikation** – Auswahl des Standard-Marktes mit automatischem Sync über `GET https://api.yadore.com/v2/markets` und strikter ISO-Validierung.
+- ✅ **Konforme Produktabfragen** – Requests an `GET https://api.yadore.com/v2/offer` setzen den Market-Parameter korrekt, respektieren Limits und erfüllen die Publisher API 2.0 Vorgaben.
+- ✅ **Verbesserte Fehlerdiagnose** – Admin-Notices und Logs zeigen die konkreten Fehlermeldungen der Yadore API (z. B. Market- oder Auth-Fehler) und erleichtern die Produktion.
+- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.4 wider.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -68,7 +68,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.3:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.4:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -266,33 +266,34 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.9.3 - GEMINI 2.0 READY RELEASE!**
+## 🎉 **v2.9.4 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v2.9.3:**
-- 🌐 Direkte Live-Verbindung zur Yadore Publisher API mit Bearer-Authentifizierung, Request-Caching und detailliertem Logging.
-- 🤖 Gemini Structured Output mit JSON-Schema liefert reproduzierbare Keywords samt Confidence-Werten.
-- 🛎️ Neue Admin Notices melden Aktivierung, fehlende API Keys und kritische Fehler unmittelbar im Dashboard.
-- 📊 API-Test-Endpunkte reagieren ohne Demo-Daten, dokumentieren Keyword & Status und geben klare Handlungsempfehlungen.
+### **Neue Highlights in v2.9.4:**
+- 🌍 Automatische Markt-Synchronisation über die Yadore Markets API mit ISO-Validierung und manueller Auswahl im Backend.
+- 💾 Zuverlässige Konfigurationsspeicherung dank überarbeitetem WordPress-Formular und nonce-validiertem Submit.
+- 🧭 Konforme Offer-Abfragen mit korrekt gesetztem `market`-Parameter, sauberem Caching und vollständigen API-Headern.
+- 📣 Detaillierte Admin-Notices und Logs für 4xx-Antworten der Yadore API inklusive Market-/Auth-Hinweisen.
+- 🧾 Aktualisierte Assets, Dokumentation und Versionshinweise für den produktiven Einsatz (2.9.4).
 
 **Alle Features sind wieder verfügbar und voll funktional!**
 
-✅ **Status:** ALLE FUNKTIONEN INTEGRIERT  
-✅ **WordPress Integration:** 100% VOLLSTÄNDIG  
-✅ **Admin Pages:** ALLE 8 SEITEN VERFÜGBAR  
-✅ **Features:** COMPLETE FEATURE SET  
-✅ **AJAX Endpoints:** ALLE 16 FUNKTIONIEREN  
-✅ **Database:** ENHANCED SCHEMA  
-✅ **Performance:** OPTIMIERT  
-✅ **Security:** ENTERPRISE GRADE  
-✅ **Design:** MODERN & RESPONSIVE  
-✅ **Analytics:** ADVANCED REPORTING  
-✅ **Tools:** COMPREHENSIVE UTILITIES  
+✅ **Status:** ALLE FUNKTIONEN INTEGRIERT
+✅ **WordPress Integration:** 100% VOLLSTÄNDIG
+✅ **Admin Pages:** ALLE 8 SEITEN VERFÜGBAR
+✅ **Features:** COMPLETE FEATURE SET
+✅ **AJAX Endpoints:** ALLE 16 FUNKTIONIEREN
+✅ **Database:** ENHANCED SCHEMA
+✅ **Performance:** OPTIMIERT
+✅ **Security:** ENTERPRISE GRADE
+✅ **Design:** MODERN & RESPONSIVE
+✅ **Analytics:** ADVANCED REPORTING
+✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v2.9.3 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.4 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.9.3** - Gemini 2.0 Ready Release
-**Feature Status: ✅ ALL INTEGRATED**  
-**WordPress Integration: ✅ 100% COMPLETE**  
+**Current Version: 2.9.4** - Production-Ready Market Release
+**Feature Status: ✅ ALL INTEGRATED**
+**WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.3 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.4 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: '2.9.3',
+        version: '2.9.4',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,
@@ -20,7 +20,7 @@
             this.initTools();
             this.initDebug();
 
-            console.log('Yadore Monetizer Pro v2.9.3 Admin - Fully Initialized');
+            console.log('Yadore Monetizer Pro v2.9.4 Admin - Fully Initialized');
         },
 
         // Dashboard functionality

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.3 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.4 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: '2.9.3',
+        version: '2.9.4',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,
@@ -25,7 +25,7 @@
             this.initScrollTriggers();
             this.initResponsiveHandling();
 
-            console.log('Yadore Monetizer Pro v2.9.3 Frontend - Initialized');
+            console.log('Yadore Monetizer Pro v2.9.4 Frontend - Initialized');
         },
 
         // Initialize product overlay

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -17,7 +17,7 @@ $current_model_label = $available_models[$current_model]['label'] ?? $current_mo
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.9.3</span>
+        <span class="version-badge">v2.9.4</span>
     </h1>
 
     <div class="yadore-ai-container">

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.9.3</span>
+        <span class="version-badge">v2.9.4</span>
     </h1>
 
     <div class="yadore-analytics-container">

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.9.3</span>
+        <span class="version-badge">v2.9.4</span>
     </h1>
 
     <div class="yadore-api-container">

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.9.3</span>
+        <span class="version-badge">v2.9.4</span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.9.3</span>
+                            <span class="info-value version-current">v2.9.4</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.9.3</span>
+        <span class="version-badge">v2.9.4</span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.9.3</span>
+                                    <span class="info-value">2.9.4</span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.9.3</span>
+        <span class="version-badge">v2.9.4</span>
     </h1>
 
     <div class="yadore-scanner-container">

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.9.3</span>
+        <span class="version-badge">v2.9.4</span>
     </h1>
 
     <?php
@@ -10,9 +10,18 @@
     if (isset($_POST['submit']) && wp_verify_nonce($_POST['yadore_nonce'], 'yadore_settings')) {
         echo '<div class="notice notice-success is-dismissible"><p>Settings saved successfully!</p></div>';
     }
+    $market_options = isset($available_markets) && is_array($available_markets) ? $available_markets : array();
+    $default_market_code = isset($default_market) ? $default_market : 'de';
+    $current_market = isset($options['yadore_market'])
+        ? $options['yadore_market']
+        : get_option('yadore_market', $default_market_code);
+    $current_market = strtolower((string) $current_market);
+    if ($current_market !== '' && !isset($market_options[$current_market])) {
+        $market_options[$current_market] = esc_html__('Manuell hinterlegt', 'yadore-monetizer');
+    }
     ?>
 
-
+    <form method="post" action="<?php echo esc_url(admin_url('admin.php?page=yadore-settings')); ?>" class="yadore-settings-form">
         <?php wp_nonce_field('yadore_settings', 'yadore_nonce'); ?>
 
         <div class="yadore-settings-container">
@@ -70,6 +79,42 @@
                                 <a href="https://yadore.com/api" target="_blank">Get your API key here</a>.
                             </p>
                             <div id="yadore-api-test-results" class="api-test-results"></div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="yadore_market" class="form-label">
+                                <strong><?php esc_html_e('Default Market', 'yadore-monetizer'); ?></strong>
+                                <span class="required">*</span>
+                            </label>
+                            <?php if (!empty($market_options)) : ?>
+                                <select name="yadore_market" id="yadore_market" class="form-select">
+                                    <?php foreach ($market_options as $market_id => $market_label) :
+                                        $market_id = is_string($market_id) ? strtolower($market_id) : '';
+                                        if ($market_id === '') {
+                                            continue;
+                                        }
+                                    ?>
+                                        <option value="<?php echo esc_attr($market_id); ?>" <?php selected($current_market, $market_id); ?>>
+                                            <?php echo esc_html(strtoupper($market_id) . ' – ' . $market_label); ?>
+                                        </option>
+                                    <?php endforeach; ?>
+                                </select>
+                                <p class="form-description">
+                                    <?php esc_html_e('Choose the market that matches your approved Yadore account. Only markets returned by the Yadore API are listed.', 'yadore-monetizer'); ?>
+                                </p>
+                            <?php else : ?>
+                                <input type="text"
+                                       name="yadore_market"
+                                       id="yadore_market"
+                                       value="<?php echo esc_attr($current_market); ?>"
+                                       class="form-input"
+                                       placeholder="<?php echo esc_attr($default_market_code); ?>"
+                                       pattern="[a-z]{2}"
+                                       title="<?php esc_attr_e('Use the two-letter market code, e.g. de, at, fr.', 'yadore-monetizer'); ?>">
+                                <p class="form-description">
+                                    <?php esc_html_e('Enter the two-letter market code (ISO 3166-1 alpha-2) you are approved for, such as de or at. The value must match a market enabled for your API key.', 'yadore-monetizer'); ?>
+                                </p>
+                            <?php endif; ?>
                         </div>
 
                         <div class="form-group">

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.9.3</span>
+        <span class="version-badge">v2.9.4</span>
     </h1>
 
     <div class="yadore-tools-container">


### PR DESCRIPTION
## Summary
- fix the settings form to reliably save options and expose a selectable default market that is synced via the Yadore Markets API
- align offer requests with the latest publisher API spec, add detailed error notices, and ensure market handling is validated
- bump documentation and assets to version 2.9.4 for a production-ready release

## Testing
- php -l yadore-monetizer-pro/yadore-monetizer.php
- php -l yadore-monetizer-pro/templates/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68d0d119f3008325b6959703bac72444