### PR TITLE
Bump plugin to 2.9.5 and accept documented Yadore API key format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v2.9.4 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.5 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.9.4 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.5 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
@@ -16,13 +16,13 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **16 AJAX Endpoints** - Alle korrekt implementiert ohne Konflikte  
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 2.9.4**
+## 🌟 **NEU IN VERSION 2.9.5**
 
 - ✅ **Stabile Einstellungen** – Das Settings-Formular nutzt jetzt ein echtes WordPress-Formular und speichert alle Optionen zuverlässig.
 - ✅ **Marktverwaltung nach API-Spezifikation** – Auswahl des Standard-Marktes mit automatischem Sync über `GET https://api.yadore.com/v2/markets` und strikter ISO-Validierung.
 - ✅ **Konforme Produktabfragen** – Requests an `GET https://api.yadore.com/v2/offer` setzen den Market-Parameter korrekt, respektieren Limits und erfüllen die Publisher API 2.0 Vorgaben.
 - ✅ **Verbesserte Fehlerdiagnose** – Admin-Notices und Logs zeigen die konkreten Fehlermeldungen der Yadore API (z. B. Market- oder Auth-Fehler) und erleichtern die Produktion.
-- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.4 wider.
+- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.5 wider.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -68,7 +68,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.4:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.5:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -266,14 +266,14 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.9.4 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v2.9.5 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v2.9.4:**
+### **Neue Highlights in v2.9.5:**
 - 🌍 Automatische Markt-Synchronisation über die Yadore Markets API mit ISO-Validierung und manueller Auswahl im Backend.
 - 💾 Zuverlässige Konfigurationsspeicherung dank überarbeitetem WordPress-Formular und nonce-validiertem Submit.
 - 🧭 Konforme Offer-Abfragen mit korrekt gesetztem `market`-Parameter, sauberem Caching und vollständigen API-Headern.
 - 📣 Detaillierte Admin-Notices und Logs für 4xx-Antworten der Yadore API inklusive Market-/Auth-Hinweisen.
-- 🧾 Aktualisierte Assets, Dokumentation und Versionshinweise für den produktiven Einsatz (2.9.4).
+- 🧾 Aktualisierte Assets, Dokumentation und Versionshinweise für den produktiven Einsatz (2.9.5).
 
 **Alle Features sind wieder verfügbar und voll funktional!**
 
@@ -289,11 +289,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v2.9.4 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.5 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.9.4** - Production-Ready Market Release
+**Current Version: 2.9.5** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.4 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.5 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: '2.9.4',
+        version: '2.9.5',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,
@@ -20,7 +20,7 @@
             this.initTools();
             this.initDebug();
 
-            console.log('Yadore Monetizer Pro v2.9.4 Admin - Fully Initialized');
+            console.log('Yadore Monetizer Pro v2.9.5 Admin - Fully Initialized');
         },
 
         // Dashboard functionality

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.4 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.5 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: '2.9.4',
+        version: '2.9.5',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,
@@ -25,7 +25,7 @@
             this.initScrollTriggers();
             this.initResponsiveHandling();
 
-            console.log('Yadore Monetizer Pro v2.9.4 Frontend - Initialized');
+            console.log('Yadore Monetizer Pro v2.9.5 Frontend - Initialized');
         },
 
         // Initialize product overlay

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -17,7 +17,7 @@ $current_model_label = $available_models[$current_model]['label'] ?? $current_mo
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.9.4</span>
+        <span class="version-badge">v2.9.5</span>
     </h1>
 
     <div class="yadore-ai-container">

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.9.4</span>
+        <span class="version-badge">v2.9.5</span>
     </h1>
 
     <div class="yadore-analytics-container">

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.9.4</span>
+        <span class="version-badge">v2.9.5</span>
     </h1>
 
     <div class="yadore-api-container">

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.9.4</span>
+        <span class="version-badge">v2.9.5</span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.9.4</span>
+                            <span class="info-value version-current">v2.9.5</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.9.4</span>
+        <span class="version-badge">v2.9.5</span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.9.4</span>
+                                    <span class="info-value">2.9.5</span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.9.4</span>
+        <span class="version-badge">v2.9.5</span>
     </h1>
 
     <div class="yadore-scanner-container">

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.9.4</span>
+        <span class="version-badge">v2.9.5</span>
     </h1>
 
     <?php

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.9.4</span>
+        <span class="version-badge">v2.9.5</span>
     </h1>
 
     <div class="yadore-tools-container">

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 2.9.4
+Version: 2.9.5
 Author: Yadore AI
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '2.9.4');
+define('YADORE_PLUGIN_VERSION', '2.9.5');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -81,7 +81,7 @@ class YadoreMonetizer {
             add_action('wp_dashboard_setup', array($this, 'add_dashboard_widgets'));
             add_action('admin_bar_menu', array($this, 'add_admin_bar_menu'), 999);
 
-            $this->log('Plugin v2.9.4 initialized successfully with complete feature set', 'info');
+            $this->log('Plugin v2.9.5 initialized successfully with complete feature set', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Plugin initialization failed', $e, 'critical');
@@ -2445,10 +2445,21 @@ $wpdb->insert($analytics_table, array(
     /** Basic sanitize helpers (single authoritative copy) */
     private function sanitize_bool($v){ return $v ? 1 : 0; }
     private function sanitize_text($v){ return sanitize_text_field( (string) $v ); }
-    private function sanitize_api_key($v){
-        $v = trim((string) $v);
-        $v = preg_replace('/\s+/', '', $v);
-        return sanitize_text_field($v);
+    private function sanitize_api_key($value){
+        $value = trim((string) $value);
+
+        if ($value === '') {
+            return '';
+        }
+
+        $value = preg_replace('/\s+/', '', $value);
+
+        // Preserve all characters allowed by the Yadore Publisher API key format (docs.yadore.com)
+        if (!preg_match('/^[A-Za-z0-9_\-:.=+\/]+$/', $value)) {
+            $value = preg_replace('/[^A-Za-z0-9_\-:.=+\/]/', '', $value);
+        }
+
+        return $value;
     }
     private function sanitize_market($value) {
         $value = strtolower(trim((string) $value));


### PR DESCRIPTION
## Summary
- bump the plugin, asset headers, templates, and documentation to version 2.9.5
- align API key sanitisation with the characters allowed by the docs so Yadore requests keep the configured key intact

## Testing
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68d0d7e3585083259de8e04405a69c36