### PR TITLE
Bump plugin to 2.9.6 for Yadore API 2.0 compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v2.9.5 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.6 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.9.5 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.6 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
@@ -16,13 +16,12 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **16 AJAX Endpoints** - Alle korrekt implementiert ohne Konflikte  
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 2.9.5**
+## 🌟 **NEU IN VERSION 2.9.6**
 
-- ✅ **Stabile Einstellungen** – Das Settings-Formular nutzt jetzt ein echtes WordPress-Formular und speichert alle Optionen zuverlässig.
-- ✅ **Marktverwaltung nach API-Spezifikation** – Auswahl des Standard-Marktes mit automatischem Sync über `GET https://api.yadore.com/v2/markets` und strikter ISO-Validierung.
-- ✅ **Konforme Produktabfragen** – Requests an `GET https://api.yadore.com/v2/offer` setzen den Market-Parameter korrekt, respektieren Limits und erfüllen die Publisher API 2.0 Vorgaben.
-- ✅ **Verbesserte Fehlerdiagnose** – Admin-Notices und Logs zeigen die konkreten Fehlermeldungen der Yadore API (z. B. Market- oder Auth-Fehler) und erleichtern die Produktion.
-- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.5 wider.
+- ✅ **Publisher API 2.0.0 konform** – Alle Requests folgen der aktuellen Yadore Publisher API (OAS 3.0) samt dokumentiertem `/openapi.yaml`-Verweis in den Admin-Docs.
+- ✅ **Großgeschriebene Markt-Codes** – Standard- und benutzerdefinierte Märkte werden automatisch als ISO-3166-1 Alpha-2 (z. B. `DE`) normalisiert, damit jeder Request akzeptiert wird.
+- ✅ **Optimierte Marktauswahl im Backend** – Dropdowns und Fallback-Felder verarbeiten Großbuchstaben konsistent und markieren manuell hinterlegte Märkte korrekt.
+- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.6 wider.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -68,7 +67,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.5:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.6:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -266,14 +265,13 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.9.5 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v2.9.6 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v2.9.5:**
-- 🌍 Automatische Markt-Synchronisation über die Yadore Markets API mit ISO-Validierung und manueller Auswahl im Backend.
-- 💾 Zuverlässige Konfigurationsspeicherung dank überarbeitetem WordPress-Formular und nonce-validiertem Submit.
-- 🧭 Konforme Offer-Abfragen mit korrekt gesetztem `market`-Parameter, sauberem Caching und vollständigen API-Headern.
-- 📣 Detaillierte Admin-Notices und Logs für 4xx-Antworten der Yadore API inklusive Market-/Auth-Hinweisen.
-- 🧾 Aktualisierte Assets, Dokumentation und Versionshinweise für den produktiven Einsatz (2.9.5).
+### **Neue Highlights in v2.9.6:**
+- 🌍 Vollständige Ausrichtung auf die Yadore Publisher API 2.0.0 (OAS 3.0) inklusive dokumentiertem `/openapi.yaml`-Verweis.
+- 🔠 Automatische Großschreibung aller Markt-Codes sorgt für valide Requests und klare Anzeige im Backend.
+- 🧭 Optimierte Marktauswahl im Settings-Interface mit konsistenter Behandlung von API-Rückgaben und manuellen Eingaben.
+- 🧾 Aktualisierte Assets, Dokumentation und Versionshinweise für den produktiven Einsatz (2.9.6).
 
 **Alle Features sind wieder verfügbar und voll funktional!**
 
@@ -289,11 +287,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v2.9.5 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.6 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.9.5** - Production-Ready Market Release
+**Current Version: 2.9.6** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.5 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.6 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: '2.9.5',
+        version: '2.9.6',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,
@@ -20,7 +20,7 @@
             this.initTools();
             this.initDebug();
 
-            console.log('Yadore Monetizer Pro v2.9.5 Admin - Fully Initialized');
+            console.log('Yadore Monetizer Pro v2.9.6 Admin - Fully Initialized');
         },
 
         // Dashboard functionality

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.5 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.6 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: '2.9.5',
+        version: '2.9.6',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,
@@ -25,7 +25,7 @@
             this.initScrollTriggers();
             this.initResponsiveHandling();
 
-            console.log('Yadore Monetizer Pro v2.9.5 Frontend - Initialized');
+            console.log('Yadore Monetizer Pro v2.9.6 Frontend - Initialized');
         },
 
         // Initialize product overlay

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -17,7 +17,7 @@ $current_model_label = $available_models[$current_model]['label'] ?? $current_mo
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.9.5</span>
+        <span class="version-badge">v2.9.6</span>
     </h1>
 
     <div class="yadore-ai-container">

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.9.5</span>
+        <span class="version-badge">v2.9.6</span>
     </h1>
 
     <div class="yadore-analytics-container">

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.9.5</span>
+        <span class="version-badge">v2.9.6</span>
     </h1>
 
     <div class="yadore-api-container">
@@ -104,6 +104,13 @@
                     <!-- Yadore API Documentation -->
                     <div class="tab-content active" id="tab-yadore">
                         <div class="api-documentation">
+                            <div class="api-spec-callout">
+                                <p>
+                                    <strong>Yadore Publisher API 2.0.0</strong> (OAS 3.0) &ndash; vollständige Spezifikation unter
+                                    <code>https://api.yadore.com/openapi.yaml</code>. Alle Endpunkte verwenden den Server
+                                    <code>https://api.yadore.com/</code>.
+                                </p>
+                            </div>
                             <div class="endpoint-section">
                                 <h3>Offer Search Endpoint</h3>
                                 <div class="endpoint-details">

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.9.5</span>
+        <span class="version-badge">v2.9.6</span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.9.5</span>
+                            <span class="info-value version-current">v2.9.6</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.9.5</span>
+        <span class="version-badge">v2.9.6</span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.9.5</span>
+                                    <span class="info-value">2.9.6</span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.9.5</span>
+        <span class="version-badge">v2.9.6</span>
     </h1>
 
     <div class="yadore-scanner-container">

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.9.5</span>
+        <span class="version-badge">v2.9.6</span>
     </h1>
 
     <?php
@@ -11,11 +11,11 @@
         echo '<div class="notice notice-success is-dismissible"><p>Settings saved successfully!</p></div>';
     }
     $market_options = isset($available_markets) && is_array($available_markets) ? $available_markets : array();
-    $default_market_code = isset($default_market) ? $default_market : 'de';
+    $default_market_code = isset($default_market) ? strtoupper($default_market) : 'DE';
     $current_market = isset($options['yadore_market'])
         ? $options['yadore_market']
         : get_option('yadore_market', $default_market_code);
-    $current_market = strtolower((string) $current_market);
+    $current_market = strtoupper((string) $current_market);
     if ($current_market !== '' && !isset($market_options[$current_market])) {
         $market_options[$current_market] = esc_html__('Manuell hinterlegt', 'yadore-monetizer');
     }
@@ -89,13 +89,13 @@
                             <?php if (!empty($market_options)) : ?>
                                 <select name="yadore_market" id="yadore_market" class="form-select">
                                     <?php foreach ($market_options as $market_id => $market_label) :
-                                        $market_id = is_string($market_id) ? strtolower($market_id) : '';
+                                        $market_id = is_string($market_id) ? strtoupper($market_id) : '';
                                         if ($market_id === '') {
                                             continue;
                                         }
                                     ?>
                                         <option value="<?php echo esc_attr($market_id); ?>" <?php selected($current_market, $market_id); ?>>
-                                            <?php echo esc_html(strtoupper($market_id) . ' – ' . $market_label); ?>
+                                            <?php echo esc_html($market_id . ' – ' . $market_label); ?>
                                         </option>
                                     <?php endforeach; ?>
                                 </select>
@@ -109,10 +109,10 @@
                                        value="<?php echo esc_attr($current_market); ?>"
                                        class="form-input"
                                        placeholder="<?php echo esc_attr($default_market_code); ?>"
-                                       pattern="[a-z]{2}"
-                                       title="<?php esc_attr_e('Use the two-letter market code, e.g. de, at, fr.', 'yadore-monetizer'); ?>">
+                                       pattern="[A-Za-z]{2}"
+                                       title="<?php esc_attr_e('Use the two-letter uppercase market code, e.g. DE, AT, FR.', 'yadore-monetizer'); ?>">
                                 <p class="form-description">
-                                    <?php esc_html_e('Enter the two-letter market code (ISO 3166-1 alpha-2) you are approved for, such as de or at. The value must match a market enabled for your API key.', 'yadore-monetizer'); ?>
+                                    <?php esc_html_e('Enter the two-letter market code (ISO 3166-1 alpha-2) you are approved for, such as DE or AT. The value must match a market enabled for your API key.', 'yadore-monetizer'); ?>
                                 </p>
                             <?php endif; ?>
                         </div>

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.9.5</span>
+        <span class="version-badge">v2.9.6</span>
     </h1>
 
     <div class="yadore-tools-container">

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 2.9.5
+Version: 2.9.6
 Author: Yadore AI
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '2.9.5');
+define('YADORE_PLUGIN_VERSION', '2.9.6');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -81,7 +81,7 @@ class YadoreMonetizer {
             add_action('wp_dashboard_setup', array($this, 'add_dashboard_widgets'));
             add_action('admin_bar_menu', array($this, 'add_admin_bar_menu'), 999);
 
-            $this->log('Plugin v2.9.5 initialized successfully with complete feature set', 'info');
+            $this->log('Plugin v2.9.6 initialized successfully with complete feature set', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Plugin initialization failed', $e, 'critical');
@@ -198,13 +198,13 @@ class YadoreMonetizer {
     private function get_default_market() {
         $locale = function_exists('get_locale') ? get_locale() : 'de_DE';
         if (is_string($locale) && strlen($locale) >= 2) {
-            $candidate = strtolower(substr($locale, 0, 2));
-            if (preg_match('/^[a-z]{2}$/', $candidate)) {
+            $candidate = strtoupper(substr($locale, 0, 2));
+            if (preg_match('/^[A-Z]{2}$/', $candidate)) {
                 return $candidate;
             }
         }
 
-        return 'de';
+        return 'DE';
     }
 
     private function set_default_options() {
@@ -2462,8 +2462,8 @@ $wpdb->insert($analytics_table, array(
         return $value;
     }
     private function sanitize_market($value) {
-        $value = strtolower(trim((string) $value));
-        if (preg_match('/^[a-z]{2}$/', $value)) {
+        $value = strtoupper(trim((string) $value));
+        if (preg_match('/^[A-Z]{2}$/', $value)) {
             return $value;
         }
 


### PR DESCRIPTION
## Summary
- bump plugin metadata and UI badges to version 2.9.6 across PHP, templates and scripts
- normalize Yadore market handling to uppercase ISO codes and align docs with the Publisher API 2.0.0 (OAS 3.0) specification
- refresh README and admin API docs with the latest specification details and version notes

## Testing
- php -l yadore-monetizer.php
- php -l templates/admin-settings.php
- php -l templates/admin-api-docs.php
- php -l templates/admin-debug.php

------
https://chatgpt.com/codex/tasks/task_e_68d0e0fecb308325ba4f66468556b9f5