### PR TITLE
Bump version to 2.9.8 and fix Gemini structured output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v2.9.7 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.8 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.9.7 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.8 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
@@ -16,12 +16,12 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **16 AJAX Endpoints** - Alle korrekt implementiert ohne Konflikte  
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 2.9.7**
+## 🌟 **NEU IN VERSION 2.9.8**
 
-- ✅ **Publisher API 2.0.0 konform** – Alle Requests folgen der aktuellen Yadore Publisher API (OAS 3.0) samt dokumentiertem `/openapi.yaml`-Verweis in den Admin-Docs.
-- ✅ **Großgeschriebene Markt-Codes** – Standard- und benutzerdefinierte Märkte werden automatisch als ISO-3166-1 Alpha-2 (z. B. `DE`) normalisiert, damit jeder Request akzeptiert wird.
-- ✅ **Optimierte Marktauswahl im Backend** – Dropdowns und Fallback-Felder verarbeiten Großbuchstaben konsistent und markieren manuell hinterlegte Märkte korrekt.
-- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.7 wider.
+- ✅ **Gemini Structured Output aktualisiert** – `responseMimeType` und `responseSchema` werden jetzt korrekt innerhalb von `generationConfig` übergeben, damit Google Gemini strukturierte JSON-Antworten akzeptiert.
+- ✅ **Gemini API Test stabilisiert** – Der Admin-Testcall meldet keine `Invalid JSON payload`-Fehler mehr und bleibt vollständig kompatibel mit der Gemini Schnittstellenbeschreibung.
+- ✅ **Publisher API 2.0.0 konform** – Alle Requests folgen weiterhin der aktuellen Yadore Publisher API (OAS 3.0) samt dokumentiertem `/openapi.yaml`-Verweis in den Admin-Docs.
+- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.8 wider.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -67,7 +67,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.7:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.8:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -265,13 +265,12 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.9.7 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v2.9.8 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v2.9.7:**
-- 🌍 Vollständige Ausrichtung auf die Yadore Publisher API 2.0.0 (OAS 3.0) inklusive dokumentiertem `/openapi.yaml`-Verweis.
-- 🔠 Automatische Großschreibung aller Markt-Codes sorgt für valide Requests und klare Anzeige im Backend.
-- 🧭 Optimierte Marktauswahl im Settings-Interface mit konsistenter Behandlung von API-Rückgaben und manuellen Eingaben.
-- 🧾 Aktualisierte Assets, Dokumentation und Versionshinweise für den produktiven Einsatz (2.9.7).
+### **Neue Highlights in v2.9.8:**
+- 🤖 Gemini Structured Output Requests erfüllen jetzt exakt die Google Vorgaben (`responseMimeType` + `responseSchema` in `generationConfig`) – keine `Invalid JSON payload`-Fehler mehr beim API-Test.
+- 📚 Admin-Dokumentation und Beispiel-Requests spiegeln die neue Schema-Struktur wider und dienen als direkte Referenz für Integrationen.
+- 🧾 Aktualisierte Assets, Dokumentation und Versionshinweise für den produktiven Einsatz (2.9.8).
 
 **Alle Features sind wieder verfügbar und voll funktional!**
 
@@ -287,11 +286,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v2.9.7 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.8 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.9.7** - Production-Ready Market Release
+**Current Version: 2.9.8** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.8 - Admin CSS (Complete) */
 .yadore-admin-wrap {
     margin: 0;
 }

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.8 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.7 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.8 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: '2.9.7',
+        version: '2.9.8',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,
@@ -25,7 +25,7 @@
             this.initTools();
             this.initDebug();
 
-            console.log('Yadore Monetizer Pro v2.9.7 Admin - Fully Initialized');
+            console.log('Yadore Monetizer Pro v2.9.8 Admin - Fully Initialized');
         },
 
         // Dashboard functionality

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.7 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.8 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: '2.9.7',
+        version: '2.9.8',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,
@@ -25,7 +25,7 @@
             this.initScrollTriggers();
             this.initResponsiveHandling();
 
-            console.log('Yadore Monetizer Pro v2.9.7 Frontend - Initialized');
+            console.log('Yadore Monetizer Pro v2.9.8 Frontend - Initialized');
         },
 
         // Initialize product overlay

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -17,7 +17,7 @@ $current_model_label = $available_models[$current_model]['label'] ?? $current_mo
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.9.7</span>
+        <span class="version-badge">v2.9.8</span>
     </h1>
 
     <div class="yadore-ai-container">
@@ -371,7 +371,7 @@ function yadoreInitializeAiManagement() {
     $('#run-ai-test').on('click', yadoreRunAiTest);
     $('#run-batch-test').on('click', yadoreRunBatchTest);
 
-    console.log('Yadore AI Management v2.9 - Initialized');
+    console.log('Yadore AI Management v2.9.8 - Initialized');
 }
 
 function yadoreLoadAiStats() {

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.9.7</span>
+        <span class="version-badge">v2.9.8</span>
     </h1>
 
     <div class="yadore-analytics-container">
@@ -319,7 +319,7 @@ function yadoreInitializeAnalytics() {
         yadoreLoadPerformanceTable($(this).val());
     });
 
-    console.log('Yadore Analytics v2.9 - Initialized');
+    console.log('Yadore Analytics v2.9.8 - Initialized');
 }
 
 function yadoreLoadAnalyticsData(period = 30) {

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.9.7</span>
+        <span class="version-badge">v2.9.8</span>
     </h1>
 
     <div class="yadore-api-container">
@@ -287,18 +287,28 @@ Accept: application/json</code></pre>
   ],
   "generationConfig": {
     "temperature": 0.3,
-    "maxOutputTokens": 50
-  },
-  "responseMimeType": "application/json",
-  "responseSchema": {
-    "type": "object",
-    "properties": {
-      "keyword": { "type": "string" },
-      "confidence": { "type": "number" },
-      "rationale": { "type": "string" }
-    },
-    "required": ["keyword"],
-    "additionalProperties": false
+    "maxOutputTokens": 50,
+    "responseMimeType": "application/json",
+    "responseSchema": {
+      "type": "OBJECT",
+      "properties": {
+        "keyword": {
+          "type": "STRING",
+          "description": "Primary product keyword describing the best affiliate opportunity."
+        },
+        "confidence": {
+          "type": "NUMBER",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "rationale": {
+          "type": "STRING",
+          "description": "Optional short explanation for the keyword choice."
+        }
+      },
+      "required": ["keyword"],
+      "propertyOrdering": ["keyword", "confidence", "rationale"]
+    }
   }
 }</code></pre>
                                     </div>
@@ -436,7 +446,7 @@ function yadoreInitializeApiDocs() {
     $('#clear-logs').on('click', yadoreClearLogs);
     $('#export-logs').on('click', yadoreExportLogs);
 
-    console.log('Yadore API Documentation v2.9 - Initialized');
+    console.log('Yadore API Documentation v2.9.8 - Initialized');
 }
 
 function yadoreLoadApiStatus() {

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,12 +2,12 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.9.7</span>
+        <span class="version-badge">v2.9.8</span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
     <div class="notice notice-success is-dismissible">
-        <p><strong>Yadore Monetizer Pro v2.9 activated successfully!</strong> All features are now available.</p>
+        <p><strong>Yadore Monetizer Pro v2.9.8 activated successfully!</strong> All features are now available.</p>
     </div>
     <?php delete_transient('yadore_activation_notice'); endif; ?>
 
@@ -311,7 +311,7 @@
                             <div class="status-indicator status-active"></div>
                             <div class="status-details">
                                 <strong>WordPress Integration</strong>
-                                <small>v2.9 - All systems operational</small>
+                                <small>v2.9.8 - All systems operational</small>
                             </div>
                         </div>
 
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.9.7</span>
+                            <span class="info-value version-current">v2.9.8</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>
@@ -363,7 +363,7 @@
                         </div>
                         <div class="info-row">
                             <span class="info-label">Database:</span>
-                            <span class="info-value">Enhanced v2.9</span>
+                            <span class="info-value">Enhanced v2.9.8</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">Features:</span>
@@ -419,7 +419,7 @@ jQuery(document).ready(function($) {
 });
 
 function yadoreInitializeDashboard() {
-    console.log('Yadore Monetizer Pro v2.9 Dashboard - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.8 Dashboard - Initialized');
 }
 
 function yadoreLoadDashboardStats() {

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.9.7</span>
+        <span class="version-badge">v2.9.8</span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.9.7</span>
+                                    <span class="info-value">2.9.8</span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>
@@ -393,7 +393,7 @@ function yadoreInitializeDebug() {
     $('#auto-scroll').on('change', yadoreToggleAutoScroll);
     $('#word-wrap').on('change', yadoreToggleWordWrap);
 
-    console.log('Yadore Debug System v2.9 - Initialized');
+    console.log('Yadore Debug System v2.9.8 - Initialized');
 }
 
 function yadoreLoadSystemHealth() {

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.9.7</span>
+        <span class="version-badge">v2.9.8</span>
     </h1>
 
     <div class="yadore-scanner-container">

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.9.7</span>
+        <span class="version-badge">v2.9.8</span>
     </h1>
 
     <?php
@@ -652,7 +652,7 @@ jQuery(document).ready(function($) {
     $('#test-gemini-api').on('click', yadoreTestGeminiApi);
     $('#test-yadore-api').on('click', yadoreTestYadoreApi);
 
-    console.log('Yadore Monetizer Pro v2.9 Settings - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.8 Settings - Initialized');
 });
 
 function yadoreTestGeminiApi() {

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.9.7</span>
+        <span class="version-badge">v2.9.8</span>
     </h1>
 
     <div class="yadore-tools-container">
@@ -494,7 +494,7 @@ function yadoreInitializeTools() {
         yadoreHandleFileUpload(this.files);
     });
 
-    console.log('Yadore Tools v2.9 - Initialized');
+    console.log('Yadore Tools v2.9.8 - Initialized');
 }
 
 function yadoreLoadToolStats() {

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 2.9.7
+Version: 2.9.8
 Author: Yadore AI
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '2.9.7');
+define('YADORE_PLUGIN_VERSION', '2.9.8');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -87,7 +87,7 @@ class YadoreMonetizer {
             add_action('wp_dashboard_setup', array($this, 'add_dashboard_widgets'));
             add_action('admin_bar_menu', array($this, 'add_admin_bar_menu'), 999);
 
-            $this->log('Plugin v2.9.7 initialized successfully with complete feature set', 'info');
+            $this->log('Plugin v2.9.8 initialized successfully with complete feature set', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Plugin initialization failed', $e, 'critical');
@@ -2186,28 +2186,28 @@ class YadoreMonetizer {
                 'generationConfig' => array(
                     'temperature' => $temperature,
                     'maxOutputTokens' => $max_tokens,
-                ),
-                'responseMimeType' => 'application/json',
-                'responseSchema' => array(
-                    'type' => 'object',
-                    'properties' => array(
-                        'keyword' => array(
-                            'type' => 'string',
-                            'description' => 'Primary product keyword describing the best affiliate opportunity.',
+                    'responseMimeType' => 'application/json',
+                    'responseSchema' => array(
+                        'type' => 'OBJECT',
+                        'properties' => array(
+                            'keyword' => array(
+                                'type' => 'STRING',
+                                'description' => 'Primary product keyword describing the best affiliate opportunity.',
+                            ),
+                            'confidence' => array(
+                                'type' => 'NUMBER',
+                                'minimum' => 0,
+                                'maximum' => 1,
+                                'description' => 'Confidence score between 0 and 1 for the extracted keyword.',
+                            ),
+                            'rationale' => array(
+                                'type' => 'STRING',
+                                'description' => 'Optional short explanation for the keyword choice.',
+                            ),
                         ),
-                        'confidence' => array(
-                            'type' => 'number',
-                            'minimum' => 0,
-                            'maximum' => 1,
-                            'description' => 'Confidence score between 0 and 1 for the extracted keyword.',
-                        ),
-                        'rationale' => array(
-                            'type' => 'string',
-                            'description' => 'Optional short explanation for the keyword choice.',
-                        ),
+                        'required' => array('keyword'),
+                        'propertyOrdering' => array('keyword', 'confidence', 'rationale'),
                     ),
-                    'required' => array('keyword'),
-                    'additionalProperties' => false,
                 ),
             );
 


### PR DESCRIPTION
## Summary
- bump the plugin version to 2.9.8 across PHP, assets, templates, and docs
- fix the Gemini request payload by moving responseMimeType/Schema into generationConfig and updating the schema to match Google requirements
- refresh the admin API example and release notes to describe the corrected structured output configuration

## Testing
- php -l yadore-monetizer.php templates/admin-ai.php templates/admin-analytics.php templates/admin-api-docs.php templates/admin-dashboard.php templates/admin-debug.php templates/admin-scanner.php templates/admin-settings.php templates/admin-tools.php

------
https://chatgpt.com/codex/tasks/task_e_68d0f324977c83258e411b42508a8133