### PR TITLE
Improve error notice dismissal and Gemini parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v2.9.8 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.9 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.9.8 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.9 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
@@ -16,12 +16,13 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **16 AJAX Endpoints** - Alle korrekt implementiert ohne Konflikte  
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 2.9.8**
+## 🌟 **NEU IN VERSION 2.9.9**
 
-- ✅ **Gemini Structured Output aktualisiert** – `responseMimeType` und `responseSchema` werden jetzt korrekt innerhalb von `generationConfig` übergeben, damit Google Gemini strukturierte JSON-Antworten akzeptiert.
-- ✅ **Gemini API Test stabilisiert** – Der Admin-Testcall meldet keine `Invalid JSON payload`-Fehler mehr und bleibt vollständig kompatibel mit der Gemini Schnittstellenbeschreibung.
-- ✅ **Publisher API 2.0.0 konform** – Alle Requests folgen weiterhin der aktuellen Yadore Publisher API (OAS 3.0) samt dokumentiertem `/openapi.yaml`-Verweis in den Admin-Docs.
-- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.8 wider.
+- ✅ **Persistente Fehlermeldungen können endlich geschlossen werden** – Kritische Admin-Notices erhalten jetzt eine Schaltfläche „Als behoben markieren" sowie ein funktionierendes `yadore_resolve_error`-Endpoint, das Einträge zuverlässig als erledigt kennzeichnet.
+- ✅ **Verbesserte Admin-Benutzeroberfläche** – Beim Wegklicken einer Fehlermeldung wird automatisch ein AJAX-Call ausgelöst und der Hinweis dauerhaft entfernt; begleitende Hinweise führen Administrator:innen zum Fehlerprotokoll im Tools-Bereich.
+- ✅ **Gemini-Integration robust gegen JSON-Formatabweichungen** – Responses mit Code-Fences, zusätzlichem Text oder Funktionsaufrufen werden automatisch bereinigt, sodass der Test-Button nicht mehr mit „API returned data that could not be parsed as JSON" scheitert.
+- ✅ **AI-Testausgaben sauber formatiert** – Ergebnisse des Gemini-Testbuttons erscheinen als strukturierte JSON-Vorschau, wodurch Diagnose- und Supportfälle wesentlich einfacher werden.
+- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.9 wider.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -67,7 +68,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.8:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.9:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -265,12 +266,12 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.9.8 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v2.9.9 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v2.9.8:**
+### **Neue Highlights in v2.9.9:**
 - 🤖 Gemini Structured Output Requests erfüllen jetzt exakt die Google Vorgaben (`responseMimeType` + `responseSchema` in `generationConfig`) – keine `Invalid JSON payload`-Fehler mehr beim API-Test.
 - 📚 Admin-Dokumentation und Beispiel-Requests spiegeln die neue Schema-Struktur wider und dienen als direkte Referenz für Integrationen.
-- 🧾 Aktualisierte Assets, Dokumentation und Versionshinweise für den produktiven Einsatz (2.9.8).
+- 🧾 Aktualisierte Assets, Dokumentation und Versionshinweise für den produktiven Einsatz (2.9.9).
 
 **Alle Features sind wieder verfügbar und voll funktional!**
 
@@ -286,11 +287,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v2.9.8 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.9 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.9.8** - Production-Ready Market Release
+**Current Version: 2.9.9** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.8 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.9 - Admin CSS (Complete) */
 .yadore-admin-wrap {
     margin: 0;
 }
@@ -21,6 +21,23 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
+}
+
+/* Notices */
+.yadore-error-notice .yadore-error-actions {
+    margin: 10px 0 0;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.yadore-error-notice .yadore-error-hint {
+    color: #646970;
+    font-size: 13px;
+}
+
+.yadore-error-notice .yadore-resolve-now .dashicons {
+    margin-right: 6px;
 }
 
 /* Card System */

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.8 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.9 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.8 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.9 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: '2.9.8',
+        version: '2.9.9',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,
@@ -25,7 +25,7 @@
             this.initScrollTriggers();
             this.initResponsiveHandling();
 
-            console.log('Yadore Monetizer Pro v2.9.8 Frontend - Initialized');
+            console.log('Yadore Monetizer Pro v2.9.9 Frontend - Initialized');
         },
 
         // Initialize product overlay

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -17,7 +17,7 @@ $current_model_label = $available_models[$current_model]['label'] ?? $current_mo
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.9.8</span>
+        <span class="version-badge">v2.9.9</span>
     </h1>
 
     <div class="yadore-ai-container">
@@ -371,7 +371,7 @@ function yadoreInitializeAiManagement() {
     $('#run-ai-test').on('click', yadoreRunAiTest);
     $('#run-batch-test').on('click', yadoreRunBatchTest);
 
-    console.log('Yadore AI Management v2.9.8 - Initialized');
+    console.log('Yadore AI Management v2.9.9 - Initialized');
 }
 
 function yadoreLoadAiStats() {

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.9.8</span>
+        <span class="version-badge">v2.9.9</span>
     </h1>
 
     <div class="yadore-analytics-container">
@@ -319,7 +319,7 @@ function yadoreInitializeAnalytics() {
         yadoreLoadPerformanceTable($(this).val());
     });
 
-    console.log('Yadore Analytics v2.9.8 - Initialized');
+    console.log('Yadore Analytics v2.9.9 - Initialized');
 }
 
 function yadoreLoadAnalyticsData(period = 30) {

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.9.8</span>
+        <span class="version-badge">v2.9.9</span>
     </h1>
 
     <div class="yadore-api-container">
@@ -446,7 +446,7 @@ function yadoreInitializeApiDocs() {
     $('#clear-logs').on('click', yadoreClearLogs);
     $('#export-logs').on('click', yadoreExportLogs);
 
-    console.log('Yadore API Documentation v2.9.8 - Initialized');
+    console.log('Yadore API Documentation v2.9.9 - Initialized');
 }
 
 function yadoreLoadApiStatus() {

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,12 +2,12 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.9.8</span>
+        <span class="version-badge">v2.9.9</span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
     <div class="notice notice-success is-dismissible">
-        <p><strong>Yadore Monetizer Pro v2.9.8 activated successfully!</strong> All features are now available.</p>
+        <p><strong>Yadore Monetizer Pro v2.9.9 activated successfully!</strong> All features are now available.</p>
     </div>
     <?php delete_transient('yadore_activation_notice'); endif; ?>
 
@@ -311,7 +311,7 @@
                             <div class="status-indicator status-active"></div>
                             <div class="status-details">
                                 <strong>WordPress Integration</strong>
-                                <small>v2.9.8 - All systems operational</small>
+                                <small>v2.9.9 - All systems operational</small>
                             </div>
                         </div>
 
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.9.8</span>
+                            <span class="info-value version-current">v2.9.9</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>
@@ -363,7 +363,7 @@
                         </div>
                         <div class="info-row">
                             <span class="info-label">Database:</span>
-                            <span class="info-value">Enhanced v2.9.8</span>
+                            <span class="info-value">Enhanced v2.9.9</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">Features:</span>
@@ -419,7 +419,7 @@ jQuery(document).ready(function($) {
 });
 
 function yadoreInitializeDashboard() {
-    console.log('Yadore Monetizer Pro v2.9.8 Dashboard - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.9 Dashboard - Initialized');
 }
 
 function yadoreLoadDashboardStats() {

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.9.8</span>
+        <span class="version-badge">v2.9.9</span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.9.8</span>
+                                    <span class="info-value">2.9.9</span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>
@@ -393,7 +393,7 @@ function yadoreInitializeDebug() {
     $('#auto-scroll').on('change', yadoreToggleAutoScroll);
     $('#word-wrap').on('change', yadoreToggleWordWrap);
 
-    console.log('Yadore Debug System v2.9.8 - Initialized');
+    console.log('Yadore Debug System v2.9.9 - Initialized');
 }
 
 function yadoreLoadSystemHealth() {

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.9.8</span>
+        <span class="version-badge">v2.9.9</span>
     </h1>
 
     <div class="yadore-scanner-container">

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.9.8</span>
+        <span class="version-badge">v2.9.9</span>
     </h1>
 
     <?php
@@ -652,7 +652,7 @@ jQuery(document).ready(function($) {
     $('#test-gemini-api').on('click', yadoreTestGeminiApi);
     $('#test-yadore-api').on('click', yadoreTestYadoreApi);
 
-    console.log('Yadore Monetizer Pro v2.9.8 Settings - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.9 Settings - Initialized');
 });
 
 function yadoreTestGeminiApi() {

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.9.8</span>
+        <span class="version-badge">v2.9.9</span>
     </h1>
 
     <div class="yadore-tools-container">
@@ -494,7 +494,7 @@ function yadoreInitializeTools() {
         yadoreHandleFileUpload(this.files);
     });
 
-    console.log('Yadore Tools v2.9.8 - Initialized');
+    console.log('Yadore Tools v2.9.9 - Initialized');
 }
 
 function yadoreLoadToolStats() {


### PR DESCRIPTION
## Summary
- bump the plugin, assets, templates and docs to version 2.9.9
- make high-severity admin notices dismissible by marking error log entries resolved through a new AJAX handler
- harden Gemini API parsing and display the admin test results as structured, escaped JSON output

## Testing
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68d0f68b7770832594751771e65a0448