### PR TITLE
Enhance AI scanner and shortcode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v2.9.9 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.10 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.9.9 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.10 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
@@ -16,13 +16,12 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **16 AJAX Endpoints** - Alle korrekt implementiert ohne Konflikte  
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 2.9.9**
+## 🌟 **NEU IN VERSION 2.9.10**
 
-- ✅ **Persistente Fehlermeldungen können endlich geschlossen werden** – Kritische Admin-Notices erhalten jetzt eine Schaltfläche „Als behoben markieren" sowie ein funktionierendes `yadore_resolve_error`-Endpoint, das Einträge zuverlässig als erledigt kennzeichnet.
-- ✅ **Verbesserte Admin-Benutzeroberfläche** – Beim Wegklicken einer Fehlermeldung wird automatisch ein AJAX-Call ausgelöst und der Hinweis dauerhaft entfernt; begleitende Hinweise führen Administrator:innen zum Fehlerprotokoll im Tools-Bereich.
-- ✅ **Gemini-Integration robust gegen JSON-Formatabweichungen** – Responses mit Code-Fences, zusätzlichem Text oder Funktionsaufrufen werden automatisch bereinigt, sodass der Test-Button nicht mehr mit „API returned data that could not be parsed as JSON" scheitert.
-- ✅ **AI-Testausgaben sauber formatiert** – Ergebnisse des Gemini-Testbuttons erscheinen als strukturierte JSON-Vorschau, wodurch Diagnose- und Supportfälle wesentlich einfacher werden.
-- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.9 wider.
+- ✅ **Gemini Token-Limit auf 10.000 erhöht** – Einstellungen und API-Requests unterstützen jetzt umfangreiche Antworten, ohne dass „maxOutputTokens"-Beschränkungen greifen.
+- ✅ **Automatischer Post-Scanner nutzt KI-Erkennung** – Beim Speichern von Inhalten werden Beiträge (sofern gewünscht) direkt mit Gemini analysiert; Mindestwortzahlen werden respektiert und Ergebnisse protokolliert.
+- ✅ **Shortcode nutzt erkannte Keywords & Live-Daten** – `[yadore_products]` greift automatisch auf die gefundenen Schlüsselwörter eines Beitrags zurück und kann das Caching pro Aufruf deaktivieren, um frische Ergebnisse aus der Yadore API zu laden.
+- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.10 wider.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -57,10 +56,10 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ```
 
 ### **Alle Parameter verfügbar:**
-- **keyword** - Produkt-Suchbegriff (erforderlich)
-- **limit** - Anzahl Produkte (3, 6, 9, 12)
+- **keyword** - Optional; nutzt automatisch das vom Scanner erkannte Keyword des aktuellen Beitrags
+- **limit** - Anzahl Produkte (Standard 6, bis zu 12 in der UI bzw. 50 über Attribute)
 - **format** - Display-Format (grid, list, inline)
-- **cache** - Caching aktivieren (true/false)
+- **cache** - Caching aktivieren (true/false) – `false` lädt frische Daten direkt aus der Yadore API
 - **class** - Custom CSS-Klassen
 
 ### **3 Display-Formate:**
@@ -68,7 +67,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.9:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.10:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -266,12 +265,12 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.9.9 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v2.9.10 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v2.9.9:**
+### **Neue Highlights in v2.9.10:**
 - 🤖 Gemini Structured Output Requests erfüllen jetzt exakt die Google Vorgaben (`responseMimeType` + `responseSchema` in `generationConfig`) – keine `Invalid JSON payload`-Fehler mehr beim API-Test.
 - 📚 Admin-Dokumentation und Beispiel-Requests spiegeln die neue Schema-Struktur wider und dienen als direkte Referenz für Integrationen.
-- 🧾 Aktualisierte Assets, Dokumentation und Versionshinweise für den produktiven Einsatz (2.9.9).
+- 🧾 Aktualisierte Assets, Dokumentation und Versionshinweise für den produktiven Einsatz (2.9.10).
 
 **Alle Features sind wieder verfügbar und voll funktional!**
 
@@ -287,11 +286,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v2.9.9 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.10 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.9.9** - Production-Ready Market Release
+**Current Version: 2.9.10** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.9 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.10 - Admin CSS (Complete) */
 .yadore-admin-wrap {
     margin: 0;
 }

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.9 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.10 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.9 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.10 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: '2.9.9',
+        version: '2.9.10',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,
@@ -26,7 +26,7 @@
             this.initDebug();
             this.initErrorNotices();
 
-            console.log('Yadore Monetizer Pro v2.9.9 Admin - Fully Initialized');
+            console.log('Yadore Monetizer Pro v2.9.10 Admin - Fully Initialized');
         },
 
         // Dashboard functionality

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.9 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.10 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: '2.9.9',
+        version: '2.9.10',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,
@@ -25,7 +25,7 @@
             this.initScrollTriggers();
             this.initResponsiveHandling();
 
-            console.log('Yadore Monetizer Pro v2.9.9 Frontend - Initialized');
+            console.log('Yadore Monetizer Pro v2.9.10 Frontend - Initialized');
         },
 
         // Initialize product overlay

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -17,7 +17,7 @@ $current_model_label = $available_models[$current_model]['label'] ?? $current_mo
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.9.9</span>
+        <span class="version-badge">v2.9.10</span>
     </h1>
 
     <div class="yadore-ai-container">
@@ -113,7 +113,7 @@ $current_model_label = $available_models[$current_model]['label'] ?? $current_mo
                                     <label>Max Tokens</label>
                                     <div class="tokens-display">
                                         <span class="token-value"><?php echo get_option('yadore_ai_max_tokens', '50'); ?></span>
-                                        <span class="token-description">tokens per response</span>
+                                        <span class="token-description">tokens per response (max. 10,000)</span>
                                     </div>
                                 </div>
                             </div>
@@ -371,7 +371,7 @@ function yadoreInitializeAiManagement() {
     $('#run-ai-test').on('click', yadoreRunAiTest);
     $('#run-batch-test').on('click', yadoreRunBatchTest);
 
-    console.log('Yadore AI Management v2.9.9 - Initialized');
+    console.log('Yadore AI Management v2.9.10 - Initialized');
 }
 
 function yadoreLoadAiStats() {

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.9.9</span>
+        <span class="version-badge">v2.9.10</span>
     </h1>
 
     <div class="yadore-analytics-container">
@@ -319,7 +319,7 @@ function yadoreInitializeAnalytics() {
         yadoreLoadPerformanceTable($(this).val());
     });
 
-    console.log('Yadore Analytics v2.9.9 - Initialized');
+    console.log('Yadore Analytics v2.9.10 - Initialized');
 }
 
 function yadoreLoadAnalyticsData(period = 30) {

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.9.9</span>
+        <span class="version-badge">v2.9.10</span>
     </h1>
 
     <div class="yadore-api-container">
@@ -446,7 +446,7 @@ function yadoreInitializeApiDocs() {
     $('#clear-logs').on('click', yadoreClearLogs);
     $('#export-logs').on('click', yadoreExportLogs);
 
-    console.log('Yadore API Documentation v2.9.9 - Initialized');
+    console.log('Yadore API Documentation v2.9.10 - Initialized');
 }
 
 function yadoreLoadApiStatus() {

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,12 +2,12 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.9.9</span>
+        <span class="version-badge">v2.9.10</span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
     <div class="notice notice-success is-dismissible">
-        <p><strong>Yadore Monetizer Pro v2.9.9 activated successfully!</strong> All features are now available.</p>
+        <p><strong>Yadore Monetizer Pro v2.9.10 activated successfully!</strong> All features are now available.</p>
     </div>
     <?php delete_transient('yadore_activation_notice'); endif; ?>
 
@@ -311,7 +311,7 @@
                             <div class="status-indicator status-active"></div>
                             <div class="status-details">
                                 <strong>WordPress Integration</strong>
-                                <small>v2.9.9 - All systems operational</small>
+                                <small>v2.9.10 - All systems operational</small>
                             </div>
                         </div>
 
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.9.9</span>
+                            <span class="info-value version-current">v2.9.10</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>
@@ -363,7 +363,7 @@
                         </div>
                         <div class="info-row">
                             <span class="info-label">Database:</span>
-                            <span class="info-value">Enhanced v2.9.9</span>
+                            <span class="info-value">Enhanced v2.9.10</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">Features:</span>
@@ -419,7 +419,7 @@ jQuery(document).ready(function($) {
 });
 
 function yadoreInitializeDashboard() {
-    console.log('Yadore Monetizer Pro v2.9.9 Dashboard - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.10 Dashboard - Initialized');
 }
 
 function yadoreLoadDashboardStats() {

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.9.9</span>
+        <span class="version-badge">v2.9.10</span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.9.9</span>
+                                    <span class="info-value">2.9.10</span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>
@@ -393,7 +393,7 @@ function yadoreInitializeDebug() {
     $('#auto-scroll').on('change', yadoreToggleAutoScroll);
     $('#word-wrap').on('change', yadoreToggleWordWrap);
 
-    console.log('Yadore Debug System v2.9.9 - Initialized');
+    console.log('Yadore Debug System v2.9.10 - Initialized');
 }
 
 function yadoreLoadSystemHealth() {

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.9.9</span>
+        <span class="version-badge">v2.9.10</span>
     </h1>
 
     <div class="yadore-scanner-container">

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.9.9</span>
+        <span class="version-badge">v2.9.10</span>
     </h1>
 
     <?php
@@ -308,14 +308,14 @@
                                     <label for="yadore_ai_max_tokens" class="form-label">
                                         <strong>Max Tokens</strong>
                                     </label>
-                                    <input type="number" 
-                                           name="yadore_ai_max_tokens" 
+                                    <input type="number"
+                                           name="yadore_ai_max_tokens"
                                            id="yadore_ai_max_tokens"
-                                           min="10" 
-                                           max="1000"
+                                           min="10"
+                                           max="10000"
                                            value="<?php echo esc_attr(get_option('yadore_ai_max_tokens', '50')); ?>"
                                            class="form-input small">
-                                    <p class="form-description">Maximum tokens for AI response</p>
+                                    <p class="form-description">Maximum tokens for AI response (up to 10,000 tokens)</p>
                                 </div>
                             </div>
                         </div>
@@ -652,7 +652,7 @@ jQuery(document).ready(function($) {
     $('#test-gemini-api').on('click', yadoreTestGeminiApi);
     $('#test-yadore-api').on('click', yadoreTestYadoreApi);
 
-    console.log('Yadore Monetizer Pro v2.9.9 Settings - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.10 Settings - Initialized');
 });
 
 function yadoreTestGeminiApi() {

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.9.9</span>
+        <span class="version-badge">v2.9.10</span>
     </h1>
 
     <div class="yadore-tools-container">
@@ -494,7 +494,7 @@ function yadoreInitializeTools() {
         yadoreHandleFileUpload(this.files);
     });
 
-    console.log('Yadore Tools v2.9.9 - Initialized');
+    console.log('Yadore Tools v2.9.10 - Initialized');
 }
 
 function yadoreLoadToolStats() {


### PR DESCRIPTION
## Summary
- bump the plugin version to 2.9.10 across documentation and assets
- allow Gemini responses up to 10,000 tokens with updated settings handling and API requests
- ensure the post scanner and auto-save workflow leverage AI keyword detection by default
- improve the `[yadore_products]` shortcode to reuse detected keywords and optionally bypass cached product data

## Testing
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68d0fbbaffc48325a719be7de8253d65