### PR TITLE
Bump version to 2.9.17 and enforce offer headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v2.9.16 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.17 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.9.16 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.17 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
@@ -16,11 +16,12 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **16 AJAX Endpoints** - Alle korrekt implementiert ohne Konflikte  
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 2.9.16**
+## 🌟 **NEU IN VERSION 2.9.17**
 
 - ✅ **Persistente Fehlerbenachrichtigungen** – Weggeklickte kritische Fehlermeldungen werden jetzt zuverlässig als gelöst markiert und tauchen erst wieder auf, wenn neue Probleme erkannt werden.
 - ✅ **Live Error- & Trace-Protokolle** – Die Debug & Error Analysis Seite lädt echte Fehlerlogs inklusive Stack Traces und Kontextdaten direkt aus der Datenbank und stellt sie übersichtlich dar.
-- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.16 wider.
+- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.17 wider.
+- ✅ **Konsistenter Yadore API Header** – Die Produktabfrage sendet jetzt Keyword- und Limit-Header automatisch passend zu deinen Einstellungen.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -66,7 +67,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.16:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.17:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -264,12 +265,12 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.9.16 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v2.9.17 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v2.9.16:**
+### **Neue Highlights in v2.9.17:**
 - 🔍 Vollständiger Offer-Trace – Wenn keine Produkte gefunden werden, dokumentiert das Plugin jetzt die komplette Anfrage samt URL, Parametern und Rohantwort für eine präzise Fehleranalyse.
 - 📊 Request- & Response-Logging – Die API-Protokolle enthalten bei leeren Ergebnissen zusätzliche Details, damit Support-Teams schneller reagieren können.
-- 🧾 Aktualisierte Assets, Dokumentation und Versionshinweise für den produktiven Einsatz (2.9.16).
+- 🧾 Aktualisierte Assets, Dokumentation und Versionshinweise für den produktiven Einsatz (2.9.17).
 
 **Alle Features sind wieder verfügbar und voll funktional!**
 
@@ -285,11 +286,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v2.9.16 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.17 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.9.16** - Production-Ready Market Release
+**Current Version: 2.9.17** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.16 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.17 - Admin CSS (Complete) */
 .yadore-admin-wrap {
     margin: 0;
 }

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.16 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.17 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.16 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.17 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: '2.9.16',
+        version: '2.9.17',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,
@@ -30,7 +30,7 @@
             this.initDebug();
             this.initErrorNotices();
 
-            console.log('Yadore Monetizer Pro v2.9.16 Admin - Fully Initialized');
+            console.log('Yadore Monetizer Pro v2.9.17 Admin - Fully Initialized');
         },
 
         // Dashboard functionality

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.16 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.17 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: '2.9.16',
+        version: '2.9.17',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,
@@ -25,7 +25,7 @@
             this.initScrollTriggers();
             this.initResponsiveHandling();
 
-            console.log('Yadore Monetizer Pro v2.9.16 Frontend - Initialized');
+            console.log('Yadore Monetizer Pro v2.9.17 Frontend - Initialized');
         },
 
         // Initialize product overlay

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -17,7 +17,7 @@ $current_model_label = $available_models[$current_model]['label'] ?? $current_mo
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.9.16</span>
+        <span class="version-badge">v2.9.17</span>
     </h1>
 
     <div class="yadore-ai-container">
@@ -371,7 +371,7 @@ function yadoreInitializeAiManagement() {
     $('#run-ai-test').on('click', yadoreRunAiTest);
     $('#run-batch-test').on('click', yadoreRunBatchTest);
 
-    console.log('Yadore AI Management v2.9.16 - Initialized');
+    console.log('Yadore AI Management v2.9.17 - Initialized');
 }
 
 function yadoreLoadAiStats() {

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.9.16</span>
+        <span class="version-badge">v2.9.17</span>
     </h1>
 
     <div class="yadore-analytics-container">
@@ -319,7 +319,7 @@ function yadoreInitializeAnalytics() {
         yadoreLoadPerformanceTable($(this).val());
     });
 
-    console.log('Yadore Analytics v2.9.16 - Initialized');
+    console.log('Yadore Analytics v2.9.17 - Initialized');
 }
 
 function yadoreLoadAnalyticsData(period = 30) {

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.9.16</span>
+        <span class="version-badge">v2.9.17</span>
     </h1>
 
     <div class="yadore-api-container">
@@ -174,6 +174,16 @@
                                                     <td>Your personal Yadore Publisher API key</td>
                                                 </tr>
                                                 <tr>
+                                                    <td><code>Keyword</code></td>
+                                                    <td>Yes</td>
+                                                    <td>Active keyword transmitted from your plugin configuration</td>
+                                                </tr>
+                                                <tr>
+                                                    <td><code>Limit</code></td>
+                                                    <td>Yes</td>
+                                                    <td>Number of offers requested based on your plugin settings</td>
+                                                </tr>
+                                                <tr>
                                                     <td><code>Accept</code></td>
                                                     <td>No</td>
                                                     <td>Use <code>application/json</code> to receive JSON responses</td>
@@ -187,6 +197,8 @@
                                         <pre><code>GET /v2/offer?keyword=smartphone&amp;limit=6&amp;market=DE HTTP/1.1
 Host: api.yadore.com
 API-Key: YOUR_API_KEY
+Keyword: smartphone
+Limit: 6
 Accept: application/json</code></pre>
                                     </div>
 
@@ -453,7 +465,7 @@ function yadoreInitializeApiDocs() {
     $('#clear-logs').on('click', yadoreClearLogs);
     $('#export-logs').on('click', yadoreExportLogs);
 
-    console.log('Yadore API Documentation v2.9.16 - Initialized');
+    console.log('Yadore API Documentation v2.9.17 - Initialized');
 }
 
 function yadoreLoadApiStatus() {

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,12 +2,12 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.9.16</span>
+        <span class="version-badge">v2.9.17</span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
     <div class="notice notice-success is-dismissible">
-        <p><strong>Yadore Monetizer Pro v2.9.16 activated successfully!</strong> All features are now available.</p>
+        <p><strong>Yadore Monetizer Pro v2.9.17 activated successfully!</strong> All features are now available.</p>
     </div>
     <?php delete_transient('yadore_activation_notice'); endif; ?>
 
@@ -311,7 +311,7 @@
                             <div class="status-indicator status-active"></div>
                             <div class="status-details">
                                 <strong>WordPress Integration</strong>
-                                <small>v2.9.16 - All systems operational</small>
+                                <small>v2.9.17 - All systems operational</small>
                             </div>
                         </div>
 
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.9.16</span>
+                            <span class="info-value version-current">v2.9.17</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>
@@ -363,7 +363,7 @@
                         </div>
                         <div class="info-row">
                             <span class="info-label">Database:</span>
-                            <span class="info-value">Enhanced v2.9.16</span>
+                            <span class="info-value">Enhanced v2.9.17</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">Features:</span>
@@ -419,7 +419,7 @@ jQuery(document).ready(function($) {
 });
 
 function yadoreInitializeDashboard() {
-    console.log('Yadore Monetizer Pro v2.9.16 Dashboard - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.17 Dashboard - Initialized');
 }
 
 function yadoreLoadDashboardStats() {

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.9.16</span>
+        <span class="version-badge">v2.9.17</span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.9.16</span>
+                                    <span class="info-value">2.9.17</span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.9.16</span>
+        <span class="version-badge">v2.9.17</span>
     </h1>
 
     <div class="yadore-scanner-container">

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.9.16</span>
+        <span class="version-badge">v2.9.17</span>
     </h1>
 
     <?php
@@ -652,7 +652,7 @@ jQuery(document).ready(function($) {
     $('#test-gemini-api').on('click', yadoreTestGeminiApi);
     $('#test-yadore-api').on('click', yadoreTestYadoreApi);
 
-    console.log('Yadore Monetizer Pro v2.9.16 Settings - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.17 Settings - Initialized');
 });
 
 function yadoreTestGeminiApi() {

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.9.16</span>
+        <span class="version-badge">v2.9.17</span>
     </h1>
 
     <div class="yadore-tools-container">
@@ -494,7 +494,7 @@ function yadoreInitializeTools() {
         yadoreHandleFileUpload(this.files);
     });
 
-    console.log('Yadore Tools v2.9.16 - Initialized');
+    console.log('Yadore Tools v2.9.17 - Initialized');
 }
 
 function yadoreLoadToolStats() {

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 2.9.16
+Version: 2.9.17
 Author: Yadore AI
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '2.9.16');
+define('YADORE_PLUGIN_VERSION', '2.9.17');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -91,7 +91,7 @@ class YadoreMonetizer {
             add_action('wp_dashboard_setup', array($this, 'add_dashboard_widgets'));
             add_action('admin_bar_menu', array($this, 'add_admin_bar_menu'), 999);
 
-            $this->log('Plugin v2.9.16 initialized successfully with complete feature set', 'info');
+            $this->log('Plugin v2.9.17 initialized successfully with complete feature set', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Plugin initialization failed', $e, 'critical');
@@ -2192,16 +2192,35 @@ class YadoreMonetizer {
             $request_url .= (strpos($endpoint, '?') === false ? '?' : '&') . $query_string;
         }
 
+        $keyword_header = isset($request_params['keyword']) ? (string) $request_params['keyword'] : '';
+        $limit_header = isset($request_params['limit']) ? (string) $request_params['limit'] : '';
+
+        $required_headers = array(
+            'Accept' => 'application/json',
+            'User-Agent' => 'YadoreMonetizer/' . YADORE_PLUGIN_VERSION,
+            'API-Key' => $api_key,
+        );
+
+        if ($keyword_header !== '') {
+            $required_headers['Keyword'] = $keyword_header;
+        }
+
+        if ($limit_header !== '') {
+            $required_headers['Limit'] = $limit_header;
+        }
+
         $args = array(
-            'headers' => array(
-                'Accept' => 'application/json',
-                'User-Agent' => 'YadoreMonetizer/' . YADORE_PLUGIN_VERSION,
-                'API-Key' => $api_key,
-            ),
+            'headers' => $required_headers,
             'timeout' => 20,
         );
 
         $args = apply_filters('yadore_products_request_args', $args, $keyword, $limit, $post_id);
+
+        if (!isset($args['headers']) || !is_array($args['headers'])) {
+            $args['headers'] = array();
+        }
+
+        $args['headers'] = array_merge($args['headers'], $required_headers);
 
         $start_time = microtime(true);
         $response = wp_remote_get($request_url, $args);


### PR DESCRIPTION
## Summary
- bump the plugin and asset version markers to 2.9.17 across the codebase and docs
- ensure Yadore offer requests always include Keyword and Limit headers based on the configured request values
- update the admin API docs to describe the new required headers

## Testing
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68d13a325de08325b4251dd324317673