### PR TITLE
Allow configuring AI detection prompt in settings

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -166,6 +166,18 @@
                 $('#temperature-value').text($(this).val());
             });
 
+            $('#reset-ai-prompt').on('click', () => {
+                const $promptField = $('#yadore_ai_prompt');
+                if (!$promptField.length) {
+                    return;
+                }
+
+                const defaultPrompt = $promptField.data('default');
+                if (typeof defaultPrompt === 'string' && defaultPrompt.length) {
+                    $promptField.val(defaultPrompt).trigger('input');
+                }
+            });
+
             // Date range picker
             $('#export-date-range').on('change', function() {
                 if ($(this).val() === 'custom') {

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -12,6 +12,11 @@ $current_model = isset($selected_gemini_model)
     ? $selected_gemini_model
     : get_option('yadore_gemini_model', 'gemini-2.0-flash');
 $current_model_label = $available_models[$current_model]['label'] ?? $current_model;
+$ai_default_prompt = YadoreMonetizer::DEFAULT_AI_PROMPT;
+$ai_current_prompt = (string) get_option('yadore_ai_prompt', $ai_default_prompt);
+if (trim($ai_current_prompt) === '') {
+    $ai_current_prompt = $ai_default_prompt;
+}
 ?>
 <div class="wrap yadore-admin-wrap">
     <h1 class="yadore-page-title">
@@ -203,7 +208,7 @@ $current_model_label = $available_models[$current_model]['label'] ?? $current_mo
                             <div class="prompt-section">
                                 <h3><span class="dashicons dashicons-editor-code"></span> Current Analysis Prompt</h3>
                                 <div class="prompt-editor">
-                                    <textarea id="ai-prompt-editor" rows="6"><?php echo esc_textarea(get_option('yadore_ai_prompt', 'Analyze this content and identify the main product category that readers would be interested in purchasing. Return only the product keyword.')); ?></textarea>
+                                    <textarea id="ai-prompt-editor" rows="6"><?php echo esc_textarea($ai_current_prompt); ?></textarea>
                                     <div class="prompt-actions">
                                         <button class="button button-primary" id="save-prompt">
                                             <span class="dashicons dashicons-saved"></span> Save Prompt

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -19,6 +19,12 @@
     if ($current_market !== '' && !isset($market_options[$current_market])) {
         $market_options[$current_market] = esc_html__('Manuell hinterlegt', 'yadore-monetizer');
     }
+    $default_ai_prompt = YadoreMonetizer::DEFAULT_AI_PROMPT;
+    $current_ai_prompt = (string) get_option('yadore_ai_prompt', $default_ai_prompt);
+    if (trim($current_ai_prompt) === '') {
+        $current_ai_prompt = $default_ai_prompt;
+    }
+
     ?>
 
     <form method="post" action="<?php echo esc_url(admin_url('admin.php?page=yadore-settings')); ?>" class="yadore-settings-form">
@@ -275,14 +281,25 @@
                                 <label for="yadore_ai_prompt" class="form-label">
                                     <strong>AI Analysis Prompt</strong>
                                 </label>
-                                <textarea name="yadore_ai_prompt" 
-                                          id="yadore_ai_prompt" 
-                                          class="form-textarea" 
+                                <textarea name="yadore_ai_prompt"
+                                          id="yadore_ai_prompt"
+                                          class="form-textarea"
                                           rows="4"
-                                          placeholder="Enter the prompt for AI content analysis"><?php echo esc_textarea(get_option('yadore_ai_prompt', 'Analyze this content and identify the main product category that readers would be interested in purchasing. Return only the product keyword.')); ?></textarea>
+                                          placeholder="<?php echo esc_attr($default_ai_prompt); ?>"
+                                          data-default="<?php echo esc_attr($default_ai_prompt); ?>"><?php echo esc_textarea($current_ai_prompt); ?></textarea>
                                 <p class="form-description">
-                                    Customize the prompt sent to the AI for content analysis. Use {title} and {content} as placeholders.
+                                    <?php esc_html_e('Customize the instruction the AI uses to determine the best product keyword for your content.', 'yadore-monetizer'); ?>
                                 </p>
+                                <p class="form-description">
+                                    <?php esc_html_e('Available placeholders:', 'yadore-monetizer'); ?> <code>{title}</code>, <code>{content}</code>
+                                </p>
+                                <p class="form-description">
+                                    <?php esc_html_e('Use these placeholders to automatically inject the post title and body into your prompt.', 'yadore-monetizer'); ?>
+                                </p>
+                                <button type="button" class="button button-secondary" id="reset-ai-prompt">
+                                    <span class="dashicons dashicons-update-alt"></span>
+                                    <?php esc_html_e('Reset to default prompt', 'yadore-monetizer'); ?>
+                                </button>
                             </div>
 
                             <div class="form-row">

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -21,6 +21,10 @@ define('YADORE_PLUGIN_FILE', __FILE__);
 
 class YadoreMonetizer {
 
+    public const DEFAULT_AI_PROMPT = 'Analyze the title and content to find the most relevant purchase-ready product keyword (brand + model when available). Provide up to three alternate keywords for backup searches and return JSON that matches the schema (keyword, alternate_keywords, confidence, rationale).';
+
+    public const LEGACY_AI_PROMPT = 'Analyze this content and identify the main product category that readers would be interested in purchasing. Return only the product keyword.';
+
     private $debug_log = [];
     private $error_log = [];
     private $api_cache = [];
@@ -179,7 +183,7 @@ class YadoreMonetizer {
             'yadore_gemini_api_key' => '',
             'yadore_gemini_model' => $this->get_default_gemini_model(),
             'yadore_ai_cache_duration' => 157680000,
-            'yadore_ai_prompt' => 'Analyze the title and content to find the most relevant purchase-ready product keyword (brand + model when available). Provide up to three alternate keywords for backup searches and return JSON that matches the schema (keyword, alternate_keywords, confidence, rationale).',
+            'yadore_ai_prompt' => self::DEFAULT_AI_PROMPT,
             'yadore_ai_temperature' => '0.3',
             'yadore_ai_max_tokens' => 50,
             'yadore_auto_scan_posts' => 1,
@@ -244,10 +248,10 @@ class YadoreMonetizer {
                 update_option('yadore_plugin_version', YADORE_PLUGIN_VERSION);
             }
 
-            $legacy_prompt = 'Analyze this content and identify the main product category that readers would be interested in purchasing. Return only the product keyword.';
+            $legacy_prompt = self::LEGACY_AI_PROMPT;
             $stored_prompt = get_option('yadore_ai_prompt', '');
             if ($stored_prompt === $legacy_prompt) {
-                update_option('yadore_ai_prompt', 'Analyze the title and content to find the most relevant purchase-ready product keyword (brand + model when available). Provide up to three alternate keywords for backup searches and return JSON that matches the schema (keyword, alternate_keywords, confidence, rationale).');
+                update_option('yadore_ai_prompt', self::DEFAULT_AI_PROMPT);
             }
 
             if (false === get_option('yadore_install_timestamp', false)) {
@@ -2848,10 +2852,10 @@ class YadoreMonetizer {
 
             $prompt_template = (string) get_option(
                 'yadore_ai_prompt',
-                'Analyze this content and identify the main product category that readers would be interested in purchasing. Return only the product keyword.'
+                self::DEFAULT_AI_PROMPT
             );
             if (trim($prompt_template) === '') {
-                $prompt_template = 'Analyze this content and identify the main product category that readers would be interested in purchasing. Return only the product keyword.';
+                $prompt_template = self::DEFAULT_AI_PROMPT;
             }
 
             $prompt = str_replace(


### PR DESCRIPTION
## Summary
- define reusable defaults for the AI detection prompt within the plugin core
- enhance the KI settings tab with a configurable prompt editor, placeholder hints and a reset-to-default action
- hook up the reset button in the admin script and mirror the stored prompt inside the AI management screen

## Testing
- php -l yadore-monetizer-pro/yadore-monetizer.php
- php -l yadore-monetizer-pro/templates/admin-settings.php
- php -l yadore-monetizer-pro/templates/admin-ai.php

------
https://chatgpt.com/codex/tasks/task_e_68d15d48d12483258baaec2685742836