### PR TITLE
Add template selection for overlays and shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v2.9.19 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.20 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.9.19 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.20 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
@@ -16,11 +16,12 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **16 AJAX Endpoints** - Alle korrekt implementiert ohne Konflikte  
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 2.9.19**
+## 🌟 **NEU IN VERSION 2.9.20**
 
-- ✅ **Stabile Yadore-Verbindung** – Die Produktsynchronisierung verarbeitet nun verschachtelte Händler-Logos korrekt, sodass gültige API-Keys nicht länger zu Abbrüchen oder „Connection Errors“ führen.
-- ✅ **Robuste Datenaufbereitung** – Produktdaten mit komplexen Strukturen werden zuverlässig bereinigt, wodurch „No products found“-Meldungen bei erfolgreichen API-Antworten verhindert werden.
-- ✅ **Aktualisierte Versionierung** – Alle Admin-Views, Assets und Dokumentationen spiegeln Version 2.9.19 wider.
+- ✅ **Template Manager für Overlays & Shortcodes** – Produkt-Templates lassen sich nun bequem per Custom Post Type verwalten und nach Typ (Overlay oder Shortcode) klassifizieren.
+- ✅ **Flexible Standard-Templates** – Neue Einstellungen für Overlay-, Auto-Injection- und Shortcode-Standardvorlagen inklusive sofort nutzbarer Default-Layouts.
+- ✅ **Shortcode Template-Attribut** – Das `[yadore_products]` Shortcode unterstützt jetzt das Attribut `template="..."`, um individuelle Layouts gezielt aufzurufen.
+- ✅ **Serverseitiges Overlay-Rendering** – Overlay-Produkte werden serverseitig anhand des ausgewählten Templates gerendert, inklusive Integration eigener Designs.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -60,13 +61,14 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 - **format** - Display-Format (grid, list, inline)
 - **cache** - Caching aktivieren (true/false) – `false` lädt frische Daten direkt aus der Yadore API
 - **class** - Custom CSS-Klassen
+- **template** - Optional; wählt ein registriertes Template (z.B. `template="default-grid"` oder `template="custom:mein-template"`)
 
 ### **3 Display-Formate:**
 📱 **Grid Layout** - Responsive Produktkarten mit Hover-Effekten  
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.19:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.20:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -264,14 +266,14 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.9.19 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v2.9.20 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v2.9.19:**
-- 🔍 Vollständiger Offer-Trace – Wenn keine Produkte gefunden werden, dokumentiert das Plugin jetzt die komplette Anfrage samt URL, Parametern und Rohantwort für eine präzise Fehleranalyse.
-- 📊 Request- & Response-Logging – Die API-Protokolle enthalten bei leeren Ergebnissen zusätzliche Details, damit Support-Teams schneller reagieren können.
-- 🧾 Aktualisierte Assets, Dokumentation und Versionshinweise für den produktiven Einsatz (2.9.19).
+### **Neue Highlights in v2.9.20:**
+- 🧩 Einheitliches Template-System – Overlay, Shortcode und Auto-Injection greifen auf das zentrale Template-Repository zurück und lassen sich unabhängig konfigurieren.
+- 🛠️ Auswahl im Admin – Neue Dropdowns in den Anzeige-Einstellungen erlauben die komfortable Wahl des Standard-Templates für Overlay, Auto-Injection und Shortcodes.
+- ✨ Verbesserte Overlay-Auslieferung – Produktempfehlungen werden serverseitig gerendert und respektieren individuelle Template-Layouts samt Inline-Styling.
 
-**Alle Features sind wieder verfügbar und voll funktional!**
+**Alle Features sind verfügbar und voll funktional!**
 
 ✅ **Status:** ALLE FUNKTIONEN INTEGRIERT
 ✅ **WordPress Integration:** 100% VOLLSTÄNDIG
@@ -285,11 +287,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v2.9.19 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.20 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.9.19** - Production-Ready Market Release
+**Current Version: 2.9.20** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.19 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.20 - Admin CSS (Complete) */
 .yadore-admin-wrap {
     margin: 0;
 }

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.19 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.20 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.19 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.20 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: '2.9.19',
+        version: '2.9.20',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,
@@ -30,7 +30,7 @@
             this.initDebug();
             this.initErrorNotices();
 
-            console.log('Yadore Monetizer Pro v2.9.19 Admin - Fully Initialized');
+            console.log('Yadore Monetizer Pro v2.9.20 Admin - Fully Initialized');
         },
 
         // Dashboard functionality

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -22,7 +22,7 @@ if (trim($ai_current_prompt) === '') {
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.9.19</span>
+        <span class="version-badge">v2.9.20</span>
     </h1>
 
     <div class="yadore-ai-container">
@@ -376,7 +376,7 @@ function yadoreInitializeAiManagement() {
     $('#run-ai-test').on('click', yadoreRunAiTest);
     $('#run-batch-test').on('click', yadoreRunBatchTest);
 
-    console.log('Yadore AI Management v2.9.19 - Initialized');
+    console.log('Yadore AI Management v2.9.20 - Initialized');
 }
 
 function yadoreLoadAiStats() {

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.9.19</span>
+        <span class="version-badge">v2.9.20</span>
     </h1>
 
     <div class="yadore-analytics-container">
@@ -319,7 +319,7 @@ function yadoreInitializeAnalytics() {
         yadoreLoadPerformanceTable($(this).val());
     });
 
-    console.log('Yadore Analytics v2.9.19 - Initialized');
+    console.log('Yadore Analytics v2.9.20 - Initialized');
 }
 
 function yadoreLoadAnalyticsData(period = 30) {

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.9.19</span>
+        <span class="version-badge">v2.9.20</span>
     </h1>
 
     <div class="yadore-api-container">
@@ -465,7 +465,7 @@ function yadoreInitializeApiDocs() {
     $('#clear-logs').on('click', yadoreClearLogs);
     $('#export-logs').on('click', yadoreExportLogs);
 
-    console.log('Yadore API Documentation v2.9.19 - Initialized');
+    console.log('Yadore API Documentation v2.9.20 - Initialized');
 }
 
 function yadoreLoadApiStatus() {

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,12 +2,12 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.9.19</span>
+        <span class="version-badge">v2.9.20</span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
     <div class="notice notice-success is-dismissible">
-        <p><strong>Yadore Monetizer Pro v2.9.19 activated successfully!</strong> All features are now available.</p>
+        <p><strong>Yadore Monetizer Pro v2.9.20 activated successfully!</strong> All features are now available.</p>
     </div>
     <?php delete_transient('yadore_activation_notice'); endif; ?>
 
@@ -311,7 +311,7 @@
                             <div class="status-indicator status-active"></div>
                             <div class="status-details">
                                 <strong>WordPress Integration</strong>
-                                <small>v2.9.19 - All systems operational</small>
+                                <small>v2.9.20 - All systems operational</small>
                             </div>
                         </div>
 
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.9.19</span>
+                            <span class="info-value version-current">v2.9.20</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>
@@ -363,7 +363,7 @@
                         </div>
                         <div class="info-row">
                             <span class="info-label">Database:</span>
-                            <span class="info-value">Enhanced v2.9.19</span>
+                            <span class="info-value">Enhanced v2.9.20</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">Features:</span>
@@ -419,7 +419,7 @@ jQuery(document).ready(function($) {
 });
 
 function yadoreInitializeDashboard() {
-    console.log('Yadore Monetizer Pro v2.9.19 Dashboard - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.20 Dashboard - Initialized');
 }
 
 function yadoreLoadDashboardStats() {

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.9.19</span>
+        <span class="version-badge">v2.9.20</span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.9.19</span>
+                                    <span class="info-value">2.9.20</span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.9.19</span>
+        <span class="version-badge">v2.9.20</span>
     </h1>
 
     <div class="yadore-scanner-container">

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.9.19</span>
+        <span class="version-badge">v2.9.20</span>
     </h1>
 
     <?php
@@ -415,6 +415,28 @@
                                     </select>
                                 </div>
                             </div>
+
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="yadore_overlay_template" class="form-label">
+                                        <strong><?php esc_html_e('Overlay Template', 'yadore-monetizer'); ?></strong>
+                                    </label>
+                                    <select name="yadore_overlay_template" id="yadore_overlay_template" class="form-select">
+                                        <?php
+                                        $overlay_template_value = get_option('yadore_overlay_template', 'default-overlay');
+                                        $overlay_choices = isset($overlay_template_choices) && is_array($overlay_template_choices)
+                                            ? $overlay_template_choices
+                                            : array('default-overlay' => __('Modern Overlay (Default)', 'yadore-monetizer'));
+                                        foreach ($overlay_choices as $value => $label) :
+                                        ?>
+                                            <option value="<?php echo esc_attr($value); ?>" <?php selected($overlay_template_value, $value); ?>>
+                                                <?php echo esc_html($label); ?>
+                                            </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                    <p class="form-description"><?php esc_html_e('Choose which template renders the product overlay.', 'yadore-monetizer'); ?></p>
+                                </div>
+                            </div>
                         </div>
 
                         <!-- Auto-Injection Settings -->
@@ -445,6 +467,63 @@
                                            value="<?php echo esc_attr(get_option('yadore_injection_position', '2')); ?>"
                                            class="form-input small">
                                     <p class="form-description">After which paragraph to inject products</p>
+                                </div>
+                            </div>
+
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="yadore_auto_injection_template" class="form-label">
+                                        <strong><?php esc_html_e('Auto-Injection Template', 'yadore-monetizer'); ?></strong>
+                                    </label>
+                                    <select name="yadore_auto_injection_template" id="yadore_auto_injection_template" class="form-select">
+                                        <?php
+                                        $auto_template_value = get_option('yadore_auto_injection_template', 'default-inline');
+                                        $shortcode_choices = isset($shortcode_template_choices) && is_array($shortcode_template_choices)
+                                            ? $shortcode_template_choices
+                                            : array(
+                                                'default-grid' => __('Product Grid (Default)', 'yadore-monetizer'),
+                                                'default-list' => __('Product List (Default)', 'yadore-monetizer'),
+                                                'default-inline' => __('Inline Highlight (Default)', 'yadore-monetizer'),
+                                            );
+                                        foreach ($shortcode_choices as $value => $label) :
+                                        ?>
+                                            <option value="<?php echo esc_attr($value); ?>" <?php selected($auto_template_value, $value); ?>>
+                                                <?php echo esc_html($label); ?>
+                                            </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                    <p class="form-description"><?php esc_html_e('Template used when products are automatically inserted into posts.', 'yadore-monetizer'); ?></p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="form-section">
+                            <h3><span class="dashicons dashicons-screenoptions"></span> <?php esc_html_e('Shortcode Display', 'yadore-monetizer'); ?></h3>
+
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="yadore_default_shortcode_template" class="form-label">
+                                        <strong><?php esc_html_e('Default Shortcode Template', 'yadore-monetizer'); ?></strong>
+                                    </label>
+                                    <select name="yadore_default_shortcode_template" id="yadore_default_shortcode_template" class="form-select">
+                                        <?php
+                                        $default_shortcode_template_value = get_option('yadore_default_shortcode_template', 'default-grid');
+                                        $shortcode_choices = isset($shortcode_template_choices) && is_array($shortcode_template_choices)
+                                            ? $shortcode_template_choices
+                                            : array(
+                                                'default-grid' => __('Product Grid (Default)', 'yadore-monetizer'),
+                                                'default-list' => __('Product List (Default)', 'yadore-monetizer'),
+                                                'default-inline' => __('Inline Highlight (Default)', 'yadore-monetizer'),
+                                            );
+                                        foreach ($shortcode_choices as $value => $label) :
+                                        ?>
+                                            <option value="<?php echo esc_attr($value); ?>" <?php selected($default_shortcode_template_value, $value); ?>>
+                                                <?php echo esc_html($label); ?>
+                                            </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                    <p class="form-description"><?php esc_html_e('Fallback template when using the shortcode without specifying a template attribute.', 'yadore-monetizer'); ?><br>
+                                        <?php esc_html_e('Override in content with the template attribute, e.g. [yadore_products template="custom:my-template"].', 'yadore-monetizer'); ?></p>
                                 </div>
                             </div>
                         </div>
@@ -669,7 +748,7 @@ jQuery(document).ready(function($) {
     $('#test-gemini-api').on('click', yadoreTestGeminiApi);
     $('#test-yadore-api').on('click', yadoreTestYadoreApi);
 
-    console.log('Yadore Monetizer Pro v2.9.19 Settings - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.20 Settings - Initialized');
 });
 
 function yadoreTestGeminiApi() {

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.9.19</span>
+        <span class="version-badge">v2.9.20</span>
     </h1>
 
     <div class="yadore-tools-container">
@@ -494,7 +494,7 @@ function yadoreInitializeTools() {
         yadoreHandleFileUpload(this.files);
     });
 
-    console.log('Yadore Tools v2.9.19 - Initialized');
+    console.log('Yadore Tools v2.9.20 - Initialized');
 }
 
 function yadoreLoadToolStats() {

--- a/templates/overlay-products-default.php
+++ b/templates/overlay-products-default.php
@@ -1,0 +1,213 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$products = isset($products) && is_array($products) ? $products : array();
+$button_label = isset($button_label) ? (string) $button_label : __('Zum Angebot →', 'yadore-monetizer');
+
+if (empty($products)) :
+    ?>
+    <div class="overlay-no-products">
+        <div class="no-products-icon">🔍</div>
+        <h3><?php echo esc_html__('No products found', 'yadore-monetizer'); ?></h3>
+        <p><?php echo esc_html__('We couldn\'t find any relevant products for this content.', 'yadore-monetizer'); ?></p>
+    </div>
+    <?php
+    return;
+endif;
+?>
+<div class="overlay-products">
+    <?php foreach ($products as $product) :
+        $price_parts = yadore_get_formatted_price_parts($product['price'] ?? array());
+        $price_amount = $price_parts['amount'] !== '' ? $price_parts['amount'] : 'N/A';
+        $price_currency = $price_parts['currency'];
+        if ($price_amount === 'N/A') {
+            $price_currency = '';
+        }
+
+        $click_url = esc_url($product['clickUrl'] ?? '#');
+        $product_id = esc_attr($product['id'] ?? '');
+        $title = esc_html($product['title'] ?? __('Product', 'yadore-monetizer'));
+        $merchant_name = esc_html($product['merchant']['name'] ?? __('Online Store', 'yadore-monetizer'));
+        $promo_text = esc_html($product['promoText'] ?? '');
+
+        $image_url = '';
+        if (!empty($product['thumbnail']['url'])) {
+            $image_url = esc_url($product['thumbnail']['url']);
+        } elseif (!empty($product['image']['url'])) {
+            $image_url = esc_url($product['image']['url']);
+        }
+        ?>
+        <div class="overlay-product"
+             data-product-id="<?php echo $product_id; ?>"
+             data-click-url="<?php echo $click_url; ?>"
+             data-yadore-click="<?php echo $product_id; ?>"
+             role="link"
+             tabindex="0">
+            <div class="overlay-product-image">
+                <?php if ($image_url !== '') : ?>
+                    <img src="<?php echo $image_url; ?>" alt="<?php echo $title; ?>" loading="lazy">
+                <?php else : ?>
+                    <div class="overlay-product-image-placeholder" aria-hidden="true">📦</div>
+                <?php endif; ?>
+
+                <?php if ($promo_text !== '') : ?>
+                    <div class="overlay-product-badge"><?php echo $promo_text; ?></div>
+                <?php endif; ?>
+            </div>
+            <div class="overlay-product-content">
+                <h4 class="overlay-product-title"><?php echo $title; ?></h4>
+                <div class="overlay-product-price">
+                    <span class="overlay-price-amount"><?php echo esc_html($price_amount); ?></span>
+                    <?php if ($price_currency !== '') : ?>
+                        <span class="overlay-price-currency"><?php echo esc_html($price_currency); ?></span>
+                    <?php endif; ?>
+                </div>
+                <div class="overlay-product-merchant">
+                    <span class="overlay-merchant-name"><?php echo sprintf(esc_html__('Available at %s', 'yadore-monetizer'), $merchant_name); ?></span>
+                </div>
+                <a href="<?php echo $click_url; ?>"
+                   class="overlay-product-button"
+                   target="_blank"
+                   rel="nofollow noopener"
+                   data-yadore-click="<?php echo $product_id; ?>">
+                    <?php echo esc_html($button_label); ?>
+                </a>
+            </div>
+        </div>
+    <?php endforeach; ?>
+</div>
+<style>
+.overlay-products {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 20px;
+    max-width: 420px;
+    margin: 0 auto;
+}
+
+.overlay-product {
+    background: #f9f9f9;
+    border-radius: 12px;
+    overflow: hidden;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    border: 1px solid #e9ecef;
+    cursor: pointer;
+}
+
+.overlay-product:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.overlay-product:focus-within,
+.overlay-product:focus {
+    outline: 2px solid #3498db;
+    outline-offset: 3px;
+}
+
+.overlay-product-image img {
+    width: 100%;
+    height: 160px;
+    object-fit: cover;
+}
+
+.overlay-product-image {
+    position: relative;
+}
+
+.overlay-product-image-placeholder {
+    width: 100%;
+    height: 160px;
+    background: #ecf0f1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 32px;
+    color: #95a5a6;
+}
+
+.overlay-product-content {
+    padding: 18px 20px;
+}
+
+.overlay-product-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #2c3e50;
+    margin: 0 0 10px 0;
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.overlay-product-price {
+    margin-bottom: 10px;
+}
+
+.overlay-price-amount {
+    font-size: 20px;
+    font-weight: 700;
+    color: #27ae60;
+}
+
+.overlay-price-currency {
+    font-size: 14px;
+    font-weight: 600;
+    margin-left: 6px;
+    color: #27ae60;
+    text-transform: uppercase;
+}
+
+.overlay-product-merchant {
+    font-size: 13px;
+    color: #7f8c8d;
+    margin-bottom: 16px;
+}
+
+.overlay-product-button {
+    display: block;
+    width: 100%;
+    padding: 12px 16px;
+    background: linear-gradient(135deg, #3498db, #2980b9);
+    color: white;
+    text-decoration: none;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 14px;
+    text-align: center;
+    transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.overlay-product-button:hover {
+    background: linear-gradient(135deg, #2980b9, #21618c);
+    transform: translateY(-2px);
+    color: white;
+    text-decoration: none;
+}
+
+.overlay-product-badge {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    background: rgba(52, 152, 219, 0.95);
+    color: #ffffff;
+    padding: 6px 10px;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+@media (max-width: 480px) {
+    .overlay-product-content {
+        padding: 16px;
+    }
+
+    .overlay-product-title {
+        font-size: 15px;
+    }
+}
+</style>


### PR DESCRIPTION
## Summary
- add template management helpers, default template options, and server-side overlay rendering support
- expose overlay, auto-injection, and shortcode template selectors in the admin along with a new default overlay template
- document the new template attribute, update versioning to 2.9.20, and adjust frontend JS to consume rendered overlay HTML

## Testing
- php -l yadore-monetizer.php
- php -l templates/overlay-products-default.php

------
https://chatgpt.com/codex/tasks/task_e_68d165fcfa0083258cb89d05ece1a33c