### PR TITLE
Prepare editable default templates and bump to v2.9.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v2.9.20 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.21 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.9.20 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.21 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
@@ -16,12 +16,13 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **16 AJAX Endpoints** - Alle korrekt implementiert ohne Konflikte  
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 2.9.20**
+## 🌟 **NEU IN VERSION 2.9.21**
 
-- ✅ **Template Manager für Overlays & Shortcodes** – Produkt-Templates lassen sich nun bequem per Custom Post Type verwalten und nach Typ (Overlay oder Shortcode) klassifizieren.
-- ✅ **Flexible Standard-Templates** – Neue Einstellungen für Overlay-, Auto-Injection- und Shortcode-Standardvorlagen inklusive sofort nutzbarer Default-Layouts.
-- ✅ **Shortcode Template-Attribut** – Das `[yadore_products]` Shortcode unterstützt jetzt das Attribut `template="..."`, um individuelle Layouts gezielt aufzurufen.
-- ✅ **Serverseitiges Overlay-Rendering** – Overlay-Produkte werden serverseitig anhand des ausgewählten Templates gerendert, inklusive Integration eigener Designs.
+- ✅ **Editierbare Standard-Templates** – Alle Built-in Layouts (Overlay, Grid, List & Inline) werden automatisch als Custom Templates angelegt und lassen sich sofort im WordPress-Editor anpassen.
+- ✅ **Vorbereitete Platzhalter-Markups** – Fertige HTML-Strukturen mit `{{token}}`-Platzhaltern inklusive `[yadore_product_loop]` machen individuelle Anpassungen ohne PHP-Code möglich.
+- ✅ **Konsistente Button-Icons** – Neue Flexbox-Regeln richten Dashicons in sämtlichen Admin-Buttons exakt auf Texthöhe aus und verbessern die Bedienbarkeit.
+- ✅ **Verfeinerte Frontend-Styles** – Optimierte CSS-Regeln für Overlays, Bild-Platzhalter und Preisangaben sorgen für ein stimmiges Erscheinungsbild auch ohne PHP-Templates.
+- ✅ **Offizielle Autorenangabe** – Das Plugin firmiert nun unter Matthes Vogel als verantwortlichem Autor.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -68,7 +69,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.20:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.21:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -266,12 +267,12 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.9.20 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v2.9.21 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v2.9.20:**
-- 🧩 Einheitliches Template-System – Overlay, Shortcode und Auto-Injection greifen auf das zentrale Template-Repository zurück und lassen sich unabhängig konfigurieren.
-- 🛠️ Auswahl im Admin – Neue Dropdowns in den Anzeige-Einstellungen erlauben die komfortable Wahl des Standard-Templates für Overlay, Auto-Injection und Shortcodes.
-- ✨ Verbesserte Overlay-Auslieferung – Produktempfehlungen werden serverseitig gerendert und respektieren individuelle Template-Layouts samt Inline-Styling.
+### **Neue Highlights in v2.9.21:**
+- 🧩 Sofort editierbare Standard-Layouts – Built-in Templates werden automatisch als Custom Posts angelegt und können ohne Vorarbeit individuell angepasst werden.
+- 🛠️ Platzhaltergestützte Markups – Die ausgelieferten HTML-Strukturen enthalten vollständige `{{token}}`-Platzhalter und `[yadore_product_loop]`-Blöcke für eigene Designs.
+- ✨ Einheitliche UI & Styles – Dashicons in Buttons sind sauber zentriert und überarbeitete CSS-Regeln verbessern Overlay-, Platzhalter- und Preis-Darstellungen.
 
 **Alle Features sind verfügbar und voll funktional!**
 
@@ -287,11 +288,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v2.9.20 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.21 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.9.20** - Production-Ready Market Release
+**Current Version: 2.9.21** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.20 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.21 - Admin CSS (Complete) */
 .yadore-admin-wrap {
     margin: 0;
 }
@@ -10,6 +10,20 @@
     margin-bottom: 30px;
     font-size: 24px;
     color: #1d2327;
+}
+
+.yadore-admin-wrap .button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.yadore-admin-wrap .button .dashicons {
+    margin: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
 }
 
 .version-badge {

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.20 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.21 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -34,7 +34,8 @@
     aspect-ratio: 16/12;
 }
 
-.yadore-product-image-placeholder {
+.yadore-product-image-placeholder,
+.overlay-product-image-placeholder {
     width: 100%;
     height: 100%;
     background: #ecf0f1;
@@ -50,6 +51,12 @@
     height: 100%;
     object-fit: cover;
     transition: transform 0.3s ease;
+}
+
+.product-image img + .yadore-product-image-placeholder,
+.inline-image img + .yadore-product-image-placeholder,
+.overlay-product-image img + .overlay-product-image-placeholder {
+    display: none;
 }
 
 .yadore-product-card:hover .product-image img {
@@ -69,6 +76,11 @@
     text-transform: uppercase;
     letter-spacing: 0.5px;
     box-shadow: 0 2px 8px rgba(255, 107, 107, 0.3);
+}
+
+.product-badge:empty,
+.overlay-product-badge:empty {
+    display: none;
 }
 
 .product-content {
@@ -230,6 +242,10 @@
     margin: 0;
 }
 
+.product-description:empty {
+    display: none;
+}
+
 .product-pricing {
     display: grid;
     gap: 8px;
@@ -255,6 +271,13 @@
     text-transform: uppercase;
     font-weight: 600;
     color: #27ae60;
+}
+
+.price-currency:empty,
+.list-price-currency:empty,
+.inline-price-currency:empty,
+.overlay-price-currency:empty {
+    display: none;
 }
 
 .merchant-info {
@@ -312,6 +335,14 @@
     gap: 20px;
     margin-bottom: 20px;
     justify-items: center;
+}
+
+.inline-products .inline-product[data-item-index] {
+    display: none;
+}
+
+.inline-products .inline-product[data-item-index="1"] {
+    display: block;
 }
 
 .inline-product {
@@ -560,6 +591,131 @@
 #yadore-overlay-close:hover {
     background: rgba(255, 255, 255, 0.2);
     transform: rotate(90deg);
+}
+
+.overlay-products {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 20px;
+    max-width: 420px;
+    margin: 0 auto;
+}
+
+.overlay-product {
+    background: #f9f9f9;
+    border-radius: 12px;
+    overflow: hidden;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    border: 1px solid #e9ecef;
+    cursor: pointer;
+}
+
+.overlay-product:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.overlay-product:focus-within,
+.overlay-product:focus {
+    outline: 2px solid #3498db;
+    outline-offset: 3px;
+}
+
+.overlay-product-image {
+    position: relative;
+}
+
+.overlay-product-image img {
+    width: 100%;
+    height: 160px;
+    object-fit: cover;
+}
+
+.overlay-product-image-placeholder {
+    height: 160px;
+}
+
+.overlay-product-content {
+    padding: 18px 20px;
+}
+
+.overlay-product-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #2c3e50;
+    margin: 0 0 10px 0;
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.overlay-product-price {
+    margin-bottom: 10px;
+}
+
+.overlay-price-amount {
+    font-size: 20px;
+    font-weight: 700;
+    color: #27ae60;
+}
+
+.overlay-price-currency {
+    font-size: 14px;
+    font-weight: 600;
+    margin-left: 6px;
+    color: #27ae60;
+    text-transform: uppercase;
+}
+
+.overlay-product-merchant {
+    font-size: 13px;
+    color: #7f8c8d;
+    margin-bottom: 16px;
+}
+
+.overlay-product-button {
+    display: block;
+    width: 100%;
+    padding: 12px 16px;
+    background: linear-gradient(135deg, #3498db, #2980b9);
+    color: white;
+    text-decoration: none;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 14px;
+    text-align: center;
+    transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.overlay-product-button:hover {
+    background: linear-gradient(135deg, #2980b9, #21618c);
+    transform: translateY(-2px);
+    color: white;
+    text-decoration: none;
+}
+
+.overlay-product-badge {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    background: rgba(52, 152, 219, 0.95);
+    color: #ffffff;
+    padding: 6px 10px;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+@media (max-width: 480px) {
+    .overlay-product-content {
+        padding: 16px;
+    }
+
+    .overlay-product-title {
+        font-size: 15px;
+    }
 }
 
 .overlay-body {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.20 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.21 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: '2.9.20',
+        version: '2.9.21',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,
@@ -30,7 +30,7 @@
             this.initDebug();
             this.initErrorNotices();
 
-            console.log('Yadore Monetizer Pro v2.9.20 Admin - Fully Initialized');
+            console.log('Yadore Monetizer Pro v2.9.21 Admin - Fully Initialized');
         },
 
         // Dashboard functionality

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.20 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.21 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: '2.9.20',
+        version: '2.9.21',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,
@@ -25,7 +25,7 @@
             this.initScrollTriggers();
             this.initResponsiveHandling();
 
-            console.log('Yadore Monetizer Pro v2.9.20 Frontend - Initialized');
+            console.log('Yadore Monetizer Pro v2.9.21 Frontend - Initialized');
         },
 
         // Initialize product overlay

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -22,7 +22,7 @@ if (trim($ai_current_prompt) === '') {
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.9.20</span>
+        <span class="version-badge">v2.9.21</span>
     </h1>
 
     <div class="yadore-ai-container">
@@ -376,7 +376,7 @@ function yadoreInitializeAiManagement() {
     $('#run-ai-test').on('click', yadoreRunAiTest);
     $('#run-batch-test').on('click', yadoreRunBatchTest);
 
-    console.log('Yadore AI Management v2.9.20 - Initialized');
+    console.log('Yadore AI Management v2.9.21 - Initialized');
 }
 
 function yadoreLoadAiStats() {

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.9.20</span>
+        <span class="version-badge">v2.9.21</span>
     </h1>
 
     <div class="yadore-analytics-container">
@@ -319,7 +319,7 @@ function yadoreInitializeAnalytics() {
         yadoreLoadPerformanceTable($(this).val());
     });
 
-    console.log('Yadore Analytics v2.9.20 - Initialized');
+    console.log('Yadore Analytics v2.9.21 - Initialized');
 }
 
 function yadoreLoadAnalyticsData(period = 30) {

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.9.20</span>
+        <span class="version-badge">v2.9.21</span>
     </h1>
 
     <div class="yadore-api-container">
@@ -465,7 +465,7 @@ function yadoreInitializeApiDocs() {
     $('#clear-logs').on('click', yadoreClearLogs);
     $('#export-logs').on('click', yadoreExportLogs);
 
-    console.log('Yadore API Documentation v2.9.20 - Initialized');
+    console.log('Yadore API Documentation v2.9.21 - Initialized');
 }
 
 function yadoreLoadApiStatus() {

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,12 +2,12 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.9.20</span>
+        <span class="version-badge">v2.9.21</span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
     <div class="notice notice-success is-dismissible">
-        <p><strong>Yadore Monetizer Pro v2.9.20 activated successfully!</strong> All features are now available.</p>
+        <p><strong>Yadore Monetizer Pro v2.9.21 activated successfully!</strong> All features are now available.</p>
     </div>
     <?php delete_transient('yadore_activation_notice'); endif; ?>
 
@@ -311,7 +311,7 @@
                             <div class="status-indicator status-active"></div>
                             <div class="status-details">
                                 <strong>WordPress Integration</strong>
-                                <small>v2.9.20 - All systems operational</small>
+                                <small>v2.9.21 - All systems operational</small>
                             </div>
                         </div>
 
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.9.20</span>
+                            <span class="info-value version-current">v2.9.21</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>
@@ -363,7 +363,7 @@
                         </div>
                         <div class="info-row">
                             <span class="info-label">Database:</span>
-                            <span class="info-value">Enhanced v2.9.20</span>
+                            <span class="info-value">Enhanced v2.9.21</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">Features:</span>
@@ -419,7 +419,7 @@ jQuery(document).ready(function($) {
 });
 
 function yadoreInitializeDashboard() {
-    console.log('Yadore Monetizer Pro v2.9.20 Dashboard - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.21 Dashboard - Initialized');
 }
 
 function yadoreLoadDashboardStats() {

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.9.20</span>
+        <span class="version-badge">v2.9.21</span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.9.20</span>
+                                    <span class="info-value">2.9.21</span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.9.20</span>
+        <span class="version-badge">v2.9.21</span>
     </h1>
 
     <div class="yadore-scanner-container">

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.9.20</span>
+        <span class="version-badge">v2.9.21</span>
     </h1>
 
     <?php
@@ -748,7 +748,7 @@ jQuery(document).ready(function($) {
     $('#test-gemini-api').on('click', yadoreTestGeminiApi);
     $('#test-yadore-api').on('click', yadoreTestYadoreApi);
 
-    console.log('Yadore Monetizer Pro v2.9.20 Settings - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.21 Settings - Initialized');
 });
 
 function yadoreTestGeminiApi() {

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.9.20</span>
+        <span class="version-badge">v2.9.21</span>
     </h1>
 
     <div class="yadore-tools-container">
@@ -494,7 +494,7 @@ function yadoreInitializeTools() {
         yadoreHandleFileUpload(this.files);
     });
 
-    console.log('Yadore Tools v2.9.20 - Initialized');
+    console.log('Yadore Tools v2.9.21 - Initialized');
 }
 
 function yadoreLoadToolStats() {

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,8 +2,8 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 2.9.20
-Author: Yadore AI
+Version: 2.9.21
+Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
 Requires at least: 5.0
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '2.9.20');
+define('YADORE_PLUGIN_VERSION', '2.9.21');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -101,7 +101,7 @@ class YadoreMonetizer {
             add_action('wp_dashboard_setup', array($this, 'add_dashboard_widgets'));
             add_action('admin_bar_menu', array($this, 'add_admin_bar_menu'), 999);
 
-            $this->log('Plugin v2.9.20 initialized successfully with complete feature set', 'info');
+            $this->log('Plugin v2.9.21 initialized successfully with complete feature set', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Plugin initialization failed', $e, 'critical');
@@ -276,8 +276,210 @@ class YadoreMonetizer {
                 ), '', 'no');
             }
 
+            $this->ensure_default_templates_editable();
+
         } catch (Exception $e) {
             $this->log_error('Failed to setup initial data', $e);
+        }
+    }
+
+    private function ensure_default_templates_editable() {
+        try {
+            if (!post_type_exists('yadore_template')) {
+                return;
+            }
+
+            $defaults = array(
+                'default-grid' => array(
+                    'slug' => 'default-grid-template',
+                    'title' => __('Product Grid (Editable)', 'yadore-monetizer'),
+                    'type' => 'shortcode',
+                    'option' => 'yadore_default_shortcode_template',
+                    'option_default' => 'default-grid',
+                    'content' => <<<'HTML'
+<div class="yadore-products-grid" data-format="grid">
+    [yadore_product_loop]
+    <div class="yadore-product-card" data-offer-id="{{id}}" data-click-url="{{click_url}}" data-yadore-click="{{id}}" role="link" tabindex="0">
+        <div class="product-image">
+            {{image_tag}}
+            <div class="yadore-product-image-placeholder" aria-hidden="true">📦</div>
+            <div class="product-badge">{{promo_text}}</div>
+        </div>
+        <div class="product-content">
+            <h3 class="product-title">{{title}}</h3>
+            <div class="product-price-section">
+                <div class="product-price">
+                    <span class="price-amount">{{price_amount}}</span>
+                    <span class="price-currency">{{price_currency}}</span>
+                </div>
+            </div>
+            <div class="product-merchant">
+                <span class="merchant-name">{{merchant_name}}</span>
+            </div>
+            <a href="{{click_url}}" class="product-cta-button" target="_blank" rel="nofollow noopener" data-yadore-click="{{id}}">
+                {{button_label}}
+            </a>
+        </div>
+    </div>
+    [/yadore_product_loop]
+</div>
+HTML
+                ),
+                'default-list' => array(
+                    'slug' => 'default-list-template',
+                    'title' => __('Product List (Editable)', 'yadore-monetizer'),
+                    'type' => 'shortcode',
+                    'option' => null,
+                    'option_default' => 'default-list',
+                    'content' => <<<'HTML'
+<div class="yadore-products-list" data-format="list">
+    [yadore_product_loop]
+    <div class="yadore-product-item" data-offer-id="{{id}}" data-click-url="{{click_url}}" data-yadore-click="{{id}}" role="link" tabindex="0">
+        <div class="product-image">
+            {{image_tag}}
+            <div class="yadore-product-image-placeholder" aria-hidden="true">📦</div>
+        </div>
+        <div class="product-details">
+            <h3 class="product-title">{{title}}</h3>
+            <p class="product-description">{{description}}</p>
+        </div>
+        <div class="product-pricing">
+            <div class="price-main">
+                <span class="list-price-amount">{{price_amount}}</span>
+                <span class="list-price-currency">{{price_currency}}</span>
+            </div>
+            <div class="merchant-info">Verfügbar bei {{merchant_name}}</div>
+        </div>
+        <div class="product-action">
+            <a href="{{click_url}}" class="list-cta-button" target="_blank" rel="nofollow noopener" data-yadore-click="{{id}}">
+                {{button_label}}
+            </a>
+        </div>
+    </div>
+    [/yadore_product_loop]
+</div>
+HTML
+                ),
+                'default-inline' => array(
+                    'slug' => 'default-inline-template',
+                    'title' => __('Inline Highlight (Editable)', 'yadore-monetizer'),
+                    'type' => 'shortcode',
+                    'option' => 'yadore_auto_injection_template',
+                    'option_default' => 'default-inline',
+                    'content' => <<<'HTML'
+<div class="yadore-products-inline" data-format="inline">
+    <div class="inline-header">
+        <h3>Empfehlung</h3>
+        <div class="inline-subtitle">Sorgfältig ausgewähltes Angebot zu diesem Beitrag</div>
+    </div>
+    <div class="inline-products">
+        [yadore_product_loop]
+        <div class="inline-product" data-item-index="{{index}}" data-offer-id="{{id}}" data-click-url="{{click_url}}" data-yadore-click="{{id}}">
+            <div class="inline-image">
+                {{image_tag}}
+                <div class="yadore-product-image-placeholder" aria-hidden="true">📦</div>
+            </div>
+            <div class="inline-details">
+                <h4 class="inline-title">{{title}}</h4>
+                <div class="inline-price-row">
+                    <div class="inline-price">
+                        <span class="inline-price-amount">{{price_amount}}</span>
+                        <span class="inline-price-currency">{{price_currency}}</span>
+                    </div>
+                </div>
+                <div class="inline-merchant">{{merchant_name}}</div>
+                <a href="{{click_url}}" class="inline-cta" target="_blank" rel="nofollow noopener" data-yadore-click="{{id}}">
+                    {{button_label}}
+                </a>
+            </div>
+        </div>
+        [/yadore_product_loop]
+    </div>
+    <div class="inline-disclaimer">
+        <small>Als Affiliate-Partner verdienen wir ggf. an qualifizierten Käufen.</small>
+    </div>
+</div>
+HTML
+                ),
+                'default-overlay' => array(
+                    'slug' => 'default-overlay-template',
+                    'title' => __('Modern Overlay (Editable)', 'yadore-monetizer'),
+                    'type' => 'overlay',
+                    'option' => 'yadore_overlay_template',
+                    'option_default' => 'default-overlay',
+                    'content' => <<<'HTML'
+<div class="overlay-products">
+    [yadore_product_loop]
+    <div class="overlay-product" data-product-id="{{id}}" data-click-url="{{click_url}}" data-yadore-click="{{id}}" role="link" tabindex="0">
+        <div class="overlay-product-image">
+            {{image_tag}}
+            <div class="overlay-product-image-placeholder" aria-hidden="true">📦</div>
+            <div class="overlay-product-badge">{{promo_text}}</div>
+        </div>
+        <div class="overlay-product-content">
+            <h4 class="overlay-product-title">{{title}}</h4>
+            <div class="overlay-product-price">
+                <span class="overlay-price-amount">{{price_amount}}</span>
+                <span class="overlay-price-currency">{{price_currency}}</span>
+            </div>
+            <div class="overlay-product-merchant">
+                <span class="overlay-merchant-name">{{merchant_name}}</span>
+            </div>
+            <a href="{{click_url}}" class="overlay-product-button" target="_blank" rel="nofollow noopener" data-yadore-click="{{id}}">
+                {{button_label}}
+            </a>
+        </div>
+    </div>
+    [/yadore_product_loop]
+</div>
+HTML
+                ),
+            );
+
+            foreach ($defaults as $key => $template) {
+                $slug = sanitize_title($template['slug'] ?? $key);
+                $type = $template['type'] ?? 'shortcode';
+
+                if ($slug === '' || !in_array($type, array('shortcode', 'overlay'), true)) {
+                    continue;
+                }
+
+                $existing = $this->get_template_post_by_slug($slug, $type);
+
+                if (!($existing instanceof WP_Post)) {
+                    $post_id = wp_insert_post(array(
+                        'post_title' => $template['title'],
+                        'post_name' => $slug,
+                        'post_content' => $template['content'],
+                        'post_status' => 'publish',
+                        'post_type' => 'yadore_template',
+                        'meta_input' => array(
+                            '_yadore_template_type' => $type,
+                        ),
+                    ), true);
+
+                    if (!is_wp_error($post_id)) {
+                        $existing = get_post($post_id);
+                    }
+                }
+
+                if ($existing instanceof WP_Post) {
+                    $option_name = $template['option'] ?? '';
+                    $option_default = $template['option_default'] ?? $key;
+
+                    if ($option_name) {
+                        $current = get_option($option_name, $option_default);
+                        if ($current === $option_default || $current === '' || $current === $key) {
+                            $storage_key = $this->get_template_storage_key($existing);
+                            if ($storage_key !== '') {
+                                update_option($option_name, $storage_key);
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception $e) {
+            $this->log_error('Failed to ensure editable templates', $e);
         }
     }
 


### PR DESCRIPTION
## Summary
- bump the plugin metadata and collateral to version 2.9.21 and update the author to Matthes Vogel
- automatically provision editable copies of the default overlay, grid, list and inline templates and point defaults at the custom variants
- refine admin/front-end styles so button icons align with text and template placeholders render cleanly

## Testing
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68d170dcc0a08325843b2fa09b13bd8a