### PR TITLE
Bump version to 2.9.22 and enable forced rescans

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v2.9.21 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.22 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.9.21 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.22 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
@@ -16,7 +16,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **16 AJAX Endpoints** - Alle korrekt implementiert ohne Konflikte  
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 2.9.21**
+## 🌟 **NEU IN VERSION 2.9.22**
 
 - ✅ **Editierbare Standard-Templates** – Alle Built-in Layouts (Overlay, Grid, List & Inline) werden automatisch als Custom Templates angelegt und lassen sich sofort im WordPress-Editor anpassen.
 - ✅ **Vorbereitete Platzhalter-Markups** – Fertige HTML-Strukturen mit `{{token}}`-Platzhaltern inklusive `[yadore_product_loop]` machen individuelle Anpassungen ohne PHP-Code möglich.
@@ -69,7 +69,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.21:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.22:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -267,9 +267,9 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.9.21 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v2.9.22 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v2.9.21:**
+### **Neue Highlights in v2.9.22:**
 - 🧩 Sofort editierbare Standard-Layouts – Built-in Templates werden automatisch als Custom Posts angelegt und können ohne Vorarbeit individuell angepasst werden.
 - 🛠️ Platzhaltergestützte Markups – Die ausgelieferten HTML-Strukturen enthalten vollständige `{{token}}`-Platzhalter und `[yadore_product_loop]`-Blöcke für eigene Designs.
 - ✨ Einheitliche UI & Styles – Dashicons in Buttons sind sauber zentriert und überarbeitete CSS-Regeln verbessern Overlay-, Platzhalter- und Preis-Darstellungen.
@@ -288,11 +288,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v2.9.21 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.22 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.9.21** - Production-Ready Market Release
+**Current Version: 2.9.22** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.21 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.22 - Admin CSS (Complete) */
 .yadore-admin-wrap {
     margin: 0;
 }

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.21 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.22 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.21 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.22 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: '2.9.21',
+        version: '2.9.22',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,
@@ -30,7 +30,7 @@
             this.initDebug();
             this.initErrorNotices();
 
-            console.log('Yadore Monetizer Pro v2.9.21 Admin - Fully Initialized');
+            console.log('Yadore Monetizer Pro v2.9.22 Admin - Fully Initialized');
         },
 
         // Dashboard functionality
@@ -658,8 +658,12 @@
                 e.preventDefault();
                 const postId = parseInt($(e.currentTarget).data('post'), 10);
                 if (!Number.isNaN(postId)) {
+                    if (!this.scannerState) {
+                        this.scannerState = {};
+                    }
+
                     this.scannerState.selectedPost = { id: postId };
-                    this.scanSinglePost();
+                    this.scanSinglePost(true);
                 }
             });
         },
@@ -751,12 +755,14 @@
             }
         },
 
-        scanSinglePost: function() {
+        scanSinglePost: function(forceRescan) {
             if (!this.scannerState || !this.scannerState.selectedPost || !this.scannerState.selectedPost.id) {
                 alert('Please select a post to scan.');
                 return;
             }
 
+            const shouldForceRescan = typeof forceRescan === 'boolean' ? forceRescan : false;
+            const forceRescanFlag = shouldForceRescan || $('#single-force-rescan').is(':checked');
             const button = $('#scan-single-post');
             button.prop('disabled', true).html('<span class="dashicons dashicons-update-alt spinning"></span> Scanning...');
 
@@ -765,7 +771,7 @@
                 nonce: this.nonce,
                 post_id: this.scannerState.selectedPost.id,
                 use_ai: $('#single-use-ai').is(':checked') ? 1 : 0,
-                force_rescan: $('#single-force-rescan').is(':checked') ? 1 : 0,
+                force_rescan: forceRescanFlag ? 1 : 0,
                 validate_products: $('#single-validate-products').is(':checked') ? 1 : 0,
                 min_words: parseInt($('#min-words').val(), 10) || 0
             }, (response) => {

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.21 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.22 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: '2.9.21',
+        version: '2.9.22',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,
@@ -25,7 +25,7 @@
             this.initScrollTriggers();
             this.initResponsiveHandling();
 
-            console.log('Yadore Monetizer Pro v2.9.21 Frontend - Initialized');
+            console.log('Yadore Monetizer Pro v2.9.22 Frontend - Initialized');
         },
 
         // Initialize product overlay

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -22,7 +22,7 @@ if (trim($ai_current_prompt) === '') {
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.9.21</span>
+        <span class="version-badge">v2.9.22</span>
     </h1>
 
     <div class="yadore-ai-container">
@@ -376,7 +376,7 @@ function yadoreInitializeAiManagement() {
     $('#run-ai-test').on('click', yadoreRunAiTest);
     $('#run-batch-test').on('click', yadoreRunBatchTest);
 
-    console.log('Yadore AI Management v2.9.21 - Initialized');
+    console.log('Yadore AI Management v2.9.22 - Initialized');
 }
 
 function yadoreLoadAiStats() {

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.9.21</span>
+        <span class="version-badge">v2.9.22</span>
     </h1>
 
     <div class="yadore-analytics-container">
@@ -319,7 +319,7 @@ function yadoreInitializeAnalytics() {
         yadoreLoadPerformanceTable($(this).val());
     });
 
-    console.log('Yadore Analytics v2.9.21 - Initialized');
+    console.log('Yadore Analytics v2.9.22 - Initialized');
 }
 
 function yadoreLoadAnalyticsData(period = 30) {

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.9.21</span>
+        <span class="version-badge">v2.9.22</span>
     </h1>
 
     <div class="yadore-api-container">
@@ -465,7 +465,7 @@ function yadoreInitializeApiDocs() {
     $('#clear-logs').on('click', yadoreClearLogs);
     $('#export-logs').on('click', yadoreExportLogs);
 
-    console.log('Yadore API Documentation v2.9.21 - Initialized');
+    console.log('Yadore API Documentation v2.9.22 - Initialized');
 }
 
 function yadoreLoadApiStatus() {

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,12 +2,12 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.9.21</span>
+        <span class="version-badge">v2.9.22</span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
     <div class="notice notice-success is-dismissible">
-        <p><strong>Yadore Monetizer Pro v2.9.21 activated successfully!</strong> All features are now available.</p>
+        <p><strong>Yadore Monetizer Pro v2.9.22 activated successfully!</strong> All features are now available.</p>
     </div>
     <?php delete_transient('yadore_activation_notice'); endif; ?>
 
@@ -311,7 +311,7 @@
                             <div class="status-indicator status-active"></div>
                             <div class="status-details">
                                 <strong>WordPress Integration</strong>
-                                <small>v2.9.21 - All systems operational</small>
+                                <small>v2.9.22 - All systems operational</small>
                             </div>
                         </div>
 
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.9.21</span>
+                            <span class="info-value version-current">v2.9.22</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>
@@ -363,7 +363,7 @@
                         </div>
                         <div class="info-row">
                             <span class="info-label">Database:</span>
-                            <span class="info-value">Enhanced v2.9.21</span>
+                            <span class="info-value">Enhanced v2.9.22</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">Features:</span>
@@ -419,7 +419,7 @@ jQuery(document).ready(function($) {
 });
 
 function yadoreInitializeDashboard() {
-    console.log('Yadore Monetizer Pro v2.9.21 Dashboard - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.22 Dashboard - Initialized');
 }
 
 function yadoreLoadDashboardStats() {

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.9.21</span>
+        <span class="version-badge">v2.9.22</span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.9.21</span>
+                                    <span class="info-value">2.9.22</span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.9.21</span>
+        <span class="version-badge">v2.9.22</span>
     </h1>
 
     <div class="yadore-scanner-container">

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.9.21</span>
+        <span class="version-badge">v2.9.22</span>
     </h1>
 
     <?php
@@ -748,7 +748,7 @@ jQuery(document).ready(function($) {
     $('#test-gemini-api').on('click', yadoreTestGeminiApi);
     $('#test-yadore-api').on('click', yadoreTestYadoreApi);
 
-    console.log('Yadore Monetizer Pro v2.9.21 Settings - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.22 Settings - Initialized');
 });
 
 function yadoreTestGeminiApi() {

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.9.21</span>
+        <span class="version-badge">v2.9.22</span>
     </h1>
 
     <div class="yadore-tools-container">
@@ -494,7 +494,7 @@ function yadoreInitializeTools() {
         yadoreHandleFileUpload(this.files);
     });
 
-    console.log('Yadore Tools v2.9.21 - Initialized');
+    console.log('Yadore Tools v2.9.22 - Initialized');
 }
 
 function yadoreLoadToolStats() {

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 2.9.21
+Version: 2.9.22
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '2.9.21');
+define('YADORE_PLUGIN_VERSION', '2.9.22');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -101,7 +101,7 @@ class YadoreMonetizer {
             add_action('wp_dashboard_setup', array($this, 'add_dashboard_widgets'));
             add_action('admin_bar_menu', array($this, 'add_admin_bar_menu'), 999);
 
-            $this->log('Plugin v2.9.21 initialized successfully with complete feature set', 'info');
+            $this->log('Plugin v2.9.22 initialized successfully with complete feature set', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Plugin initialization failed', $e, 'critical');


### PR DESCRIPTION
## Summary
- bump the plugin version to 2.9.22 across core files, assets, templates, and documentation
- ensure the "Recent Scan Results" rescan button forces a keyword refresh even when a result already exists

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d17cc025d083258478ac653a0c0f3c