### PR TITLE
Add palette-based template color controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v2.9.25 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.26 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.9.25 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.26 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
@@ -16,11 +16,13 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **19 AJAX Endpoints** - Alle korrekt implementiert inkl. Cache-Tools & Diagnostics
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 2.9.25**
+## 🌟 **NEU IN VERSION 2.9.26**
 
-- ✅ **Cache-Dashboard & Statistiken** – Tools- und Debug-Seiten zeigen jetzt Cache-Größe, Einträge und Hit-Rate aus dem neuen Telemetrie-System.
-- ✅ **Neue Cache-AJAX-Endpunkte** – `yadore_get_tool_stats`, `yadore_clear_cache` und `yadore_analyze_cache` arbeiten vollständig per AJAX ohne Seitenreload.
-- ✅ **Automatisches Hit/Miss-Tracking** – Produkt- und AI-Anfragen aktualisieren die Cache-Telemetrie inklusive Reset bei Aktivierung oder manueller Bereinigung.
+- ✅ **Palette-basierte Template-Farben** – Alle Overlay- und Shortcode-Layouts lassen sich jetzt direkt im Backend mit einer festen Farbpalette branden.
+- ✅ **Intuitive Farbwähler im Backend** – Hex-Werte, Vorschau und Palette-Swatches sorgen für konsistente Markenfarben ohne eigenes CSS.
+- ✅ **Globale CSS-Variablen** – Frontend-Templates nutzen dynamische Variablen für Buttons, Badges, Platzhalter und Dark-Mode-Anpassungen.
+- ✅ **Cache-Dashboard & Statistiken** – Telemetrie zu Cache-Größe, Einträgen und Hit-Rate bleibt erhalten und wurde auf Version 2.9.26 abgestimmt.
+- ✅ **Cache-AJAX-Endpunkte** – `yadore_get_tool_stats`, `yadore_clear_cache` und `yadore_analyze_cache` arbeiten weiterhin vollständig per AJAX.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -67,7 +69,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.25:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.26:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -269,12 +271,13 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.9.25 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v2.9.26 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v2.9.25:**
-- 📊 Cache-Dashboard im Admin – Tools- und Debug-Seiten liefern Live-Statistiken zu Größe, Einträgen und Hit-Rate.
-- 🧼 Ein-Klick-Cache-Bereinigung – `yadore_clear_cache` leert Produkt-, AI- und Transient-Caches inklusive Telemetrie-Reset.
-- 🤖 Automatisches Hit/Miss-Tracking – Jede Produkt- und AI-Abfrage aktualisiert die Cache-Metriken für präzisere Analysen.
+### **Neue Highlights in v2.9.26:**
+- 🎨 Palette-basierte Template-Farben – Branding für alle Overlay- und Shortcode-Layouts direkt aus dem Backend.
+- 🖌️ Farbpaletten & Hex-Ausgabe – Farbwähler mit Vorschau und Palette sorgen für konsistente Markenfarben ohne Custom-CSS.
+- 🌓 CSS-Variablen & Dark-Mode – Buttons, Badges und Platzhalter reagieren automatisch auf deine Palette und den Dark-Mode.
+- 📊 Cache-Dashboard & Telemetrie – Live-Statistiken zu Cache-Größe, Einträgen und Hit/Miss-Verhältnis bleiben auf 2.9.26 optimiert.
 
 **Alle Features sind verfügbar und voll funktional!**
 
@@ -290,11 +293,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v2.9.25 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.26 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.9.25** - Production-Ready Market Release
+**Current Version: 2.9.26** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.25 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.26 - Admin CSS (Complete) */
 .yadore-admin-wrap {
     margin: 0;
 }
@@ -177,6 +177,91 @@
     font-size: 14px;
     color: #646970;
     font-weight: 500;
+}
+
+/* Color palette controls */
+.color-settings-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 24px;
+    margin-top: 16px;
+}
+
+.color-settings-card {
+    background: #f8f9fb;
+    border: 1px solid #e1e5e9;
+    border-radius: 12px;
+    padding: 20px;
+}
+
+.color-settings-card h4 {
+    margin: 0 0 16px;
+    font-size: 16px;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.color-field {
+    margin-bottom: 18px;
+}
+
+.color-field:last-child {
+    margin-bottom: 0;
+}
+
+.color-input-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 8px;
+}
+
+.color-picker-input {
+    width: 56px;
+    height: 36px;
+    padding: 0;
+    border-radius: 6px;
+    border: 1px solid #c3c4c7;
+    cursor: pointer;
+}
+
+.color-value-display {
+    width: 96px;
+    border-radius: 6px;
+    border: 1px solid #d0d5dd;
+    padding: 6px 8px;
+    font-family: monospace;
+    font-size: 13px;
+    background: #ffffff;
+    color: #1d2327;
+    text-transform: uppercase;
+}
+
+.color-palette-swatches {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 10px;
+}
+
+.color-swatch {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    padding: 0;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.color-swatch:hover {
+    transform: scale(1.08);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+}
+
+.color-swatch:focus {
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
 }
 
 /* Feature Status */

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,15 +1,16 @@
-/* Yadore Monetizer Pro v2.9.25 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.26 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 24px;
     margin: 24px 0;
     padding: 0;
+    background-color: var(--yadore-background, transparent);
 }
 
 .yadore-product-card {
-    background: white;
-    border: 1px solid #e9ecef;
+    background: var(--yadore-card-bg, #ffffff);
+    border: 1px solid var(--yadore-border, #e9ecef);
     border-radius: 16px;
     overflow: hidden;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
@@ -20,11 +21,11 @@
 
 .yadore-product-card:hover {
     transform: translateY(-8px);
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 8px 32px var(--yadore-primary-shadow, rgba(52, 152, 219, 0.15));
 }
 
 .yadore-product-card:focus {
-    outline: 2px solid #3498db;
+    outline: 2px solid var(--yadore-primary, #3498db);
     outline-offset: 3px;
 }
 
@@ -38,11 +39,11 @@
 .overlay-product-image-placeholder {
     width: 100%;
     height: 100%;
-    background: #ecf0f1;
+    background: var(--yadore-placeholder, #ecf0f1);
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #95a5a6;
+    color: var(--yadore-placeholder-text, #95a5a6);
     font-size: 32px;
 }
 
@@ -67,15 +68,15 @@
     position: absolute;
     top: 12px;
     right: 12px;
-    background: linear-gradient(135deg, #ff6b6b, #ee5a52);
-    color: white;
+    background: linear-gradient(135deg, var(--yadore-badge-light, #ff6b6b), var(--yadore-badge-dark, #ee5a52));
+    color: var(--yadore-badge-text, #ffffff);
     padding: 6px 12px;
     border-radius: 20px;
     font-size: 12px;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    box-shadow: 0 2px 8px rgba(255, 107, 107, 0.3);
+    box-shadow: 0 2px 8px var(--yadore-badge-shadow, rgba(255, 107, 107, 0.3));
 }
 
 .product-badge:empty,
@@ -95,7 +96,7 @@
     margin: 0;
     font-size: 18px;
     font-weight: 700;
-    color: #2c3e50;
+    color: var(--yadore-text, #2c3e50);
     line-height: 1.3;
     display: -webkit-box;
     -webkit-line-clamp: 2;
@@ -118,21 +119,21 @@
 .price-amount {
     font-size: 24px;
     font-weight: 800;
-    color: #27ae60;
+    color: var(--yadore-accent, #27ae60);
     letter-spacing: -0.5px;
 }
 
 .price-currency {
     font-size: 16px;
     font-weight: 600;
-    color: #27ae60;
+    color: var(--yadore-accent, #27ae60);
 }
 
 .product-merchant {
     display: flex;
     align-items: center;
     gap: 8px;
-    color: #7f8c8d;
+    color: var(--yadore-muted, #7f8c8d);
     font-size: 14px;
 }
 
@@ -147,8 +148,8 @@
     gap: 8px;
     width: 100%;
     padding: 14px 20px;
-    background: linear-gradient(135deg, #3498db, #2980b9);
-    color: white;
+    background: linear-gradient(135deg, var(--yadore-primary-light, #5dade2), var(--yadore-primary-dark, #2980b9));
+    color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
     border-radius: 12px;
     font-weight: 600;
@@ -162,10 +163,10 @@
 }
 
 .product-cta-button:hover {
-    background: linear-gradient(135deg, #2980b9, #21618c);
+    background: linear-gradient(135deg, var(--yadore-primary-dark, #2980b9), var(--yadore-primary-darker, #21618c));
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(52, 152, 219, 0.4);
-    color: white;
+    box-shadow: 0 6px 20px var(--yadore-primary-shadow, rgba(52, 152, 219, 0.4));
+    color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
 }
 
@@ -179,6 +180,7 @@
     flex-direction: column;
     gap: 16px;
     margin: 24px 0;
+    background-color: var(--yadore-background, transparent);
 }
 
 .yadore-product-item {
@@ -186,22 +188,22 @@
     grid-template-columns: 120px 1fr auto auto;
     gap: 20px;
     align-items: center;
-    background: white;
+    background: var(--yadore-card-bg, #ffffff);
     padding: 20px;
     border-radius: 12px;
-    border: 1px solid #e9ecef;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    border: 1px solid var(--yadore-border, #e9ecef);
+    box-shadow: 0 2px 8px var(--yadore-primary-shadow, rgba(52, 152, 219, 0.1));
     transition: all 0.3s ease;
     cursor: pointer;
 }
 
 .yadore-product-item:hover {
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+    box-shadow: 0 4px 16px var(--yadore-primary-shadow, rgba(52, 152, 219, 0.15));
     transform: translateY(-2px);
 }
 
 .yadore-product-item:focus {
-    outline: 2px solid #3498db;
+    outline: 2px solid var(--yadore-primary, #3498db);
     outline-offset: 3px;
 }
 
@@ -231,12 +233,12 @@
 .product-details .product-title {
     font-size: 16px;
     margin: 0;
-    color: #2c3e50;
+    color: var(--yadore-text, #2c3e50);
     font-weight: 600;
 }
 
 .product-description {
-    color: #7f8c8d;
+    color: var(--yadore-muted, #7f8c8d);
     font-size: 14px;
     line-height: 1.4;
     margin: 0;
@@ -259,7 +261,7 @@
     gap: 4px;
     font-size: 18px;
     font-weight: 700;
-    color: #27ae60;
+    color: var(--yadore-accent, #27ae60);
 }
 
 .list-price-amount {
@@ -270,7 +272,7 @@
     display: inline-block;
     text-transform: uppercase;
     font-weight: 600;
-    color: #27ae60;
+    color: var(--yadore-accent, #27ae60);
 }
 
 .price-currency:empty,
@@ -282,13 +284,13 @@
 
 .merchant-info {
     font-size: 12px;
-    color: #7f8c8d;
+    color: var(--yadore-muted, #7f8c8d);
 }
 
 .list-cta-button {
     padding: 10px 20px;
-    background: #3498db;
-    color: white;
+    background: linear-gradient(135deg, var(--yadore-primary-light, #5dade2), var(--yadore-primary-dark, #2980b9));
+    color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
     border-radius: 8px;
     font-weight: 600;
@@ -298,18 +300,18 @@
 }
 
 .list-cta-button:hover {
-    background: #2980b9;
-    color: white;
+    background: linear-gradient(135deg, var(--yadore-primary-dark, #2980b9), var(--yadore-primary-darker, #21618c));
+    color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
 }
 
 /* Inline View */
 .yadore-products-inline {
-    background: #f8f9fa;
+    background: var(--yadore-background, var(--yadore-card-bg-muted, #f8f9fa));
     padding: 24px;
     border-radius: 16px;
     margin: 32px 0;
-    border: 1px solid #e9ecef;
+    border: 1px solid var(--yadore-border, #e9ecef);
 }
 
 .inline-header {
@@ -320,12 +322,12 @@
 .inline-header h3 {
     margin: 0 0 8px 0;
     font-size: 20px;
-    color: #2c3e50;
+    color: var(--yadore-text, #2c3e50);
     font-weight: 700;
 }
 
 .inline-subtitle {
-    color: #7f8c8d;
+    color: var(--yadore-muted, #7f8c8d);
     font-size: 14px;
 }
 
@@ -346,10 +348,10 @@
 }
 
 .inline-product {
-    background: white;
+    background: var(--yadore-card-bg, #ffffff);
     padding: 16px;
     border-radius: 12px;
-    border: 1px solid #e9ecef;
+    border: 1px solid var(--yadore-border, #e9ecef);
     transition: all 0.3s ease;
     text-align: center;
     width: 100%;
@@ -358,12 +360,12 @@
 }
 
 .inline-product:hover {
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 16px var(--yadore-primary-shadow, rgba(52, 152, 219, 0.15));
     transform: translateY(-4px);
 }
 
 .inline-product:focus {
-    outline: 2px solid #3498db;
+    outline: 2px solid var(--yadore-primary, #3498db);
     outline-offset: 3px;
 }
 
@@ -388,7 +390,7 @@
 .inline-title {
     font-size: 14px;
     font-weight: 600;
-    color: #2c3e50;
+    color: var(--yadore-text, #2c3e50);
     margin: 0 0 8px 0;
     line-height: 1.3;
     display: -webkit-box;
@@ -404,7 +406,7 @@
 .inline-price {
     font-size: 16px;
     font-weight: 700;
-    color: #27ae60;
+    color: var(--yadore-accent, #27ae60);
 }
 
 .inline-price-amount {
@@ -416,20 +418,20 @@
     margin-left: 4px;
     text-transform: uppercase;
     font-weight: 600;
-    color: #27ae60;
+    color: var(--yadore-accent, #27ae60);
 }
 
 .inline-merchant {
     font-size: 11px;
-    color: #7f8c8d;
+    color: var(--yadore-muted, #7f8c8d);
     margin-bottom: 12px;
 }
 
 .inline-cta {
     display: inline-block;
     padding: 8px 16px;
-    background: #3498db;
-    color: white;
+    background: linear-gradient(135deg, var(--yadore-primary-light, #5dade2), var(--yadore-primary-dark, #2980b9));
+    color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
     border-radius: 6px;
     font-weight: 600;
@@ -438,19 +440,19 @@
 }
 
 .inline-cta:hover {
-    background: #2980b9;
-    color: white;
+    background: linear-gradient(135deg, var(--yadore-primary-dark, #2980b9), var(--yadore-primary-darker, #21618c));
+    color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
 }
 
 .inline-disclaimer {
     text-align: center;
     padding-top: 16px;
-    border-top: 1px solid #e9ecef;
+    border-top: 1px solid var(--yadore-border, #e9ecef);
 }
 
 .inline-disclaimer small {
-    color: #95a5a6;
+    color: var(--yadore-placeholder-text, #95a5a6);
     font-size: 11px;
     font-style: italic;
 }
@@ -461,14 +463,14 @@
 .inline-no-products {
     text-align: center;
     padding: 40px 20px;
-    color: #7f8c8d;
+    color: var(--yadore-muted, #7f8c8d);
 }
 
 .yadore-no-products {
     grid-column: 1 / -1;
-    background: #f8f9fa;
+    background: var(--yadore-card-bg-muted, #f8f9fa);
     border-radius: 12px;
-    border: 2px dashed #dee2e6;
+    border: 2px dashed var(--yadore-border-strong, #dee2e6);
 }
 
 .no-products-icon {
@@ -480,7 +482,7 @@
 .yadore-no-products h3 {
     margin: 0 0 8px 0;
     font-size: 18px;
-    color: #6c757d;
+    color: var(--yadore-text, #2c3e50);
 }
 
 .yadore-no-products p {
@@ -542,7 +544,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%) scale(0.8);
-    background: white;
+    background: var(--yadore-card-bg, #ffffff);
     border-radius: 20px;
     max-width: 90vw;
     width: min(720px, 90vw);
@@ -561,8 +563,8 @@
 }
 
 .overlay-header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
+    background: linear-gradient(135deg, var(--yadore-primary-light, #5dade2) 0%, var(--yadore-primary-dark, #2980b9) 100%);
+    color: var(--yadore-primary-contrast, #ffffff);
     padding: 20px 24px;
     display: flex;
     align-items: center;
@@ -579,7 +581,7 @@
 #yadore-overlay-close {
     background: none;
     border: none;
-    color: white;
+    color: var(--yadore-primary-contrast, #ffffff);
     font-size: 28px;
     cursor: pointer;
     padding: 0;
@@ -607,22 +609,22 @@
 }
 
 .overlay-product {
-    background: #f9f9f9;
+    background: var(--yadore-card-bg, #f9f9f9);
     border-radius: 12px;
     overflow: hidden;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
-    border: 1px solid #e9ecef;
+    border: 1px solid var(--yadore-border, #e9ecef);
     cursor: pointer;
 }
 
 .overlay-product:hover {
     transform: translateY(-4px);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+    box-shadow: 0 8px 24px var(--yadore-primary-shadow, rgba(52, 152, 219, 0.12));
 }
 
 .overlay-product:focus-within,
 .overlay-product:focus {
-    outline: 2px solid #3498db;
+    outline: 2px solid var(--yadore-primary, #3498db);
     outline-offset: 3px;
 }
 
@@ -647,7 +649,7 @@
 .overlay-product-title {
     font-size: 16px;
     font-weight: 600;
-    color: #2c3e50;
+    color: var(--yadore-text, #2c3e50);
     margin: 0 0 10px 0;
     line-height: 1.4;
     display: -webkit-box;
@@ -663,20 +665,20 @@
 .overlay-price-amount {
     font-size: 20px;
     font-weight: 700;
-    color: #27ae60;
+    color: var(--yadore-accent, #27ae60);
 }
 
 .overlay-price-currency {
     font-size: 14px;
     font-weight: 600;
     margin-left: 6px;
-    color: #27ae60;
+    color: var(--yadore-accent, #27ae60);
     text-transform: uppercase;
 }
 
 .overlay-product-merchant {
     font-size: 13px;
-    color: #7f8c8d;
+    color: var(--yadore-muted, #7f8c8d);
     margin-bottom: 16px;
 }
 
@@ -684,8 +686,8 @@
     display: block;
     width: 100%;
     padding: 12px 16px;
-    background: linear-gradient(135deg, #3498db, #2980b9);
-    color: white;
+    background: linear-gradient(135deg, var(--yadore-primary-light, #5dade2), var(--yadore-primary-dark, #2980b9));
+    color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
     border-radius: 8px;
     font-weight: 600;
@@ -695,9 +697,9 @@
 }
 
 .overlay-product-button:hover {
-    background: linear-gradient(135deg, #2980b9, #21618c);
+    background: linear-gradient(135deg, var(--yadore-primary-dark, #2980b9), var(--yadore-primary-darker, #21618c));
     transform: translateY(-2px);
-    color: white;
+    color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
 }
 
@@ -705,8 +707,8 @@
     position: absolute;
     top: 12px;
     left: 12px;
-    background: rgba(52, 152, 219, 0.95);
-    color: #ffffff;
+    background: var(--yadore-badge-rgba, rgba(52, 152, 219, 0.95));
+    color: var(--yadore-badge-text, #ffffff);
     padding: 6px 10px;
     border-radius: 20px;
     font-size: 12px;
@@ -734,14 +736,14 @@
 .overlay-loading {
     text-align: center;
     padding: 40px 20px;
-    color: #7f8c8d;
+    color: var(--yadore-muted, #7f8c8d);
 }
 
 .loading-spinner {
     width: 32px;
     height: 32px;
-    border: 3px solid #f3f3f3;
-    border-top: 3px solid #3498db;
+    border: 3px solid var(--yadore-card-bg-muted, #f3f3f3);
+    border-top: 3px solid var(--yadore-primary, #3498db);
     border-radius: 50%;
     animation: spin 1s linear infinite;
     margin: 0 auto 16px;
@@ -851,33 +853,33 @@
     .yadore-products-grid .yadore-product-card,
     .yadore-products-list .yadore-product-item,
     .inline-product {
-        background: #2c3e50;
-        border-color: #34495e;
-        color: #ecf0f1;
+        background: var(--yadore-card-bg-dark, #2c3e50);
+        border-color: var(--yadore-border-strong, #34495e);
+        color: var(--yadore-text-contrast, #ecf0f1);
     }
 
     .product-title {
-        color: #ecf0f1;
+        color: var(--yadore-text-contrast, #ecf0f1);
     }
 
     .product-description,
     .merchant-info,
     .inline-merchant {
-        color: #bdc3c7;
+        color: var(--yadore-muted-light, #bdc3c7);
     }
 
     .yadore-products-inline {
-        background: #34495e;
-        border-color: #4a6741;
+        background: var(--yadore-card-bg-dark, #34495e);
+        border-color: var(--yadore-border-strong, #4a6741);
     }
 
     .inline-header h3 {
-        color: #ecf0f1;
+        color: var(--yadore-text-contrast, #ecf0f1);
     }
 
     #yadore-overlay-content {
-        background: #2c3e50;
-        color: #ecf0f1;
+        background: var(--yadore-card-bg-dark, #2c3e50);
+        color: var(--yadore-text-contrast, #ecf0f1);
     }
 }
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.25 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.26 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: '2.9.25',
+        version: '2.9.26',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,
@@ -30,7 +30,7 @@
             this.initDebug();
             this.initErrorNotices();
 
-            console.log('Yadore Monetizer Pro v2.9.25 Admin - Fully Initialized');
+            console.log('Yadore Monetizer Pro v2.9.26 Admin - Fully Initialized');
         },
 
         // Dashboard functionality
@@ -194,6 +194,32 @@
                     this.resetSettings();
                 }
             });
+
+            // Color palette interactions
+            $('.color-picker-input').on('input change', function() {
+                const value = ($(this).val() || '').toString().toUpperCase();
+                $(this).closest('.color-input-wrapper').find('.color-value-display').val(value);
+            });
+
+            $('.color-value-display').on('focus', function() {
+                $(this).select();
+            });
+
+            $('.color-swatch').on('click', function() {
+                const target = $(this).data('target');
+                const color = ($(this).data('color') || '').toString().toUpperCase();
+
+                if (!target || !color) {
+                    return;
+                }
+
+                const $input = $('#' + target);
+                if ($input.length) {
+                    $input.val(color).trigger('input');
+                }
+            });
+
+            $('.color-picker-input').trigger('input');
         },
 
         resetSettings: function() {

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.25 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.26 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: '2.9.25',
+        version: '2.9.26',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,
@@ -28,7 +28,7 @@
             this.initScrollTriggers();
             this.initResponsiveHandling();
 
-            console.log('Yadore Monetizer Pro v2.9.25 Frontend - Initialized');
+            console.log('Yadore Monetizer Pro v2.9.26 Frontend - Initialized');
         },
 
         // Initialize product overlay

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -22,7 +22,7 @@ if (trim($ai_current_prompt) === '') {
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.9.25</span>
+        <span class="version-badge">v2.9.26</span>
     </h1>
 
     <div class="yadore-ai-container">
@@ -376,7 +376,7 @@ function yadoreInitializeAiManagement() {
     $('#run-ai-test').on('click', yadoreRunAiTest);
     $('#run-batch-test').on('click', yadoreRunBatchTest);
 
-    console.log('Yadore AI Management v2.9.25 - Initialized');
+    console.log('Yadore AI Management v2.9.26 - Initialized');
 }
 
 function yadoreLoadAiStats() {

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.9.25</span>
+        <span class="version-badge">v2.9.26</span>
     </h1>
 
     <div class="yadore-analytics-container">
@@ -319,7 +319,7 @@ function yadoreInitializeAnalytics() {
         yadoreLoadPerformanceTable($(this).val());
     });
 
-    console.log('Yadore Analytics v2.9.25 - Initialized');
+    console.log('Yadore Analytics v2.9.26 - Initialized');
 }
 
 function yadoreLoadAnalyticsData(period = 30) {

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.9.25</span>
+        <span class="version-badge">v2.9.26</span>
     </h1>
 
     <div class="yadore-api-container">
@@ -465,7 +465,7 @@ function yadoreInitializeApiDocs() {
     $('#clear-logs').on('click', yadoreClearLogs);
     $('#export-logs').on('click', yadoreExportLogs);
 
-    console.log('Yadore API Documentation v2.9.25 - Initialized');
+    console.log('Yadore API Documentation v2.9.26 - Initialized');
 }
 
 function yadoreLoadApiStatus() {

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,12 +2,12 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.9.25</span>
+        <span class="version-badge">v2.9.26</span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
     <div class="notice notice-success is-dismissible">
-        <p><strong>Yadore Monetizer Pro v2.9.25 activated successfully!</strong> All features are now available.</p>
+        <p><strong>Yadore Monetizer Pro v2.9.26 activated successfully!</strong> All features are now available.</p>
     </div>
     <?php delete_transient('yadore_activation_notice'); endif; ?>
 
@@ -311,7 +311,7 @@
                             <div class="status-indicator status-active"></div>
                             <div class="status-details">
                                 <strong>WordPress Integration</strong>
-                                <small>v2.9.25 - All systems operational</small>
+                                <small>v2.9.26 - All systems operational</small>
                             </div>
                         </div>
 
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.9.25</span>
+                            <span class="info-value version-current">v2.9.26</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>
@@ -363,7 +363,7 @@
                         </div>
                         <div class="info-row">
                             <span class="info-label">Database:</span>
-                            <span class="info-value">Enhanced v2.9.25</span>
+                            <span class="info-value">Enhanced v2.9.26</span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">Features:</span>
@@ -419,7 +419,7 @@ jQuery(document).ready(function($) {
 });
 
 function yadoreInitializeDashboard() {
-    console.log('Yadore Monetizer Pro v2.9.25 Dashboard - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.26 Dashboard - Initialized');
 }
 
 function yadoreLoadDashboardStats() {

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.9.25</span>
+        <span class="version-badge">v2.9.26</span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.9.25</span>
+                                    <span class="info-value">2.9.26</span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.9.25</span>
+        <span class="version-badge">v2.9.26</span>
     </h1>
 
     <div class="yadore-scanner-container">

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.9.25</span>
+        <span class="version-badge">v2.9.26</span>
     </h1>
 
     <?php
@@ -24,6 +24,68 @@
     if (trim($current_ai_prompt) === '') {
         $current_ai_prompt = $default_ai_prompt;
     }
+
+    $plugin_instance = class_exists('YadoreMonetizer') ? YadoreMonetizer::get_instance() : null;
+    $color_palette = isset($color_palette) && is_array($color_palette)
+        ? $color_palette
+        : ($plugin_instance instanceof YadoreMonetizer ? $plugin_instance->get_color_palette() : array());
+    $shortcode_colors = isset($shortcode_colors) && is_array($shortcode_colors)
+        ? $shortcode_colors
+        : ($plugin_instance instanceof YadoreMonetizer ? $plugin_instance->get_template_colors('shortcode') : array());
+    $overlay_colors = isset($overlay_colors) && is_array($overlay_colors)
+        ? $overlay_colors
+        : ($plugin_instance instanceof YadoreMonetizer ? $plugin_instance->get_template_colors('overlay') : array());
+
+    $color_field_definitions = array(
+        'primary' => array(
+            'label' => esc_html__('Primary color', 'yadore-monetizer'),
+            'description' => esc_html__('Used for buttons, highlights and interactive elements.', 'yadore-monetizer'),
+        ),
+        'button_text' => array(
+            'label' => esc_html__('Primary text', 'yadore-monetizer'),
+            'description' => esc_html__('Text color for primary buttons and overlays.', 'yadore-monetizer'),
+        ),
+        'accent' => array(
+            'label' => esc_html__('Accent color', 'yadore-monetizer'),
+            'description' => esc_html__('Applies to prices and emphasis text.', 'yadore-monetizer'),
+        ),
+        'text' => array(
+            'label' => esc_html__('Heading text', 'yadore-monetizer'),
+            'description' => esc_html__('Used for product titles and main copy.', 'yadore-monetizer'),
+        ),
+        'muted' => array(
+            'label' => esc_html__('Muted text', 'yadore-monetizer'),
+            'description' => esc_html__('Secondary information such as merchants or disclaimers.', 'yadore-monetizer'),
+        ),
+        'border' => array(
+            'label' => esc_html__('Borders', 'yadore-monetizer'),
+            'description' => esc_html__('Card outlines, separators and focus rings.', 'yadore-monetizer'),
+        ),
+        'background' => array(
+            'label' => esc_html__('Template background', 'yadore-monetizer'),
+            'description' => esc_html__('Wrapper background for template containers.', 'yadore-monetizer'),
+        ),
+        'card_background' => array(
+            'label' => esc_html__('Card surface', 'yadore-monetizer'),
+            'description' => esc_html__('Individual product cards and overlays.', 'yadore-monetizer'),
+        ),
+        'placeholder' => array(
+            'label' => esc_html__('Placeholder background', 'yadore-monetizer'),
+            'description' => esc_html__('Image placeholders and loading states.', 'yadore-monetizer'),
+        ),
+        'placeholder_text' => array(
+            'label' => esc_html__('Placeholder icon', 'yadore-monetizer'),
+            'description' => esc_html__('Icon color for placeholders and subtle text.', 'yadore-monetizer'),
+        ),
+        'badge' => array(
+            'label' => esc_html__('Badge background', 'yadore-monetizer'),
+            'description' => esc_html__('Promo badges and highlight ribbons.', 'yadore-monetizer'),
+        ),
+        'badge_text' => array(
+            'label' => esc_html__('Badge text', 'yadore-monetizer'),
+            'description' => esc_html__('Text color for promotional badges.', 'yadore-monetizer'),
+        ),
+    );
 
     ?>
 
@@ -540,6 +602,99 @@
                                 </div>
                             </div>
                         </div>
+
+                        <div class="form-section">
+                            <h3><span class="dashicons dashicons-art"></span> <?php esc_html_e('Template Colors', 'yadore-monetizer'); ?></h3>
+                            <p class="form-description"><?php esc_html_e('Fine-tune the colors used by the built-in templates. Select a tone from the palette or enter custom hex values.', 'yadore-monetizer'); ?></p>
+                            <div class="color-settings-grid">
+                                <div class="color-settings-card">
+                                    <h4><?php esc_html_e('Shortcode Templates', 'yadore-monetizer'); ?></h4>
+                                    <?php foreach ($color_field_definitions as $color_key => $definition) :
+                                        $field_id = 'yadore_shortcode_colors_' . $color_key;
+                                        $field_value = isset($shortcode_colors[$color_key]) ? (string) $shortcode_colors[$color_key] : '';
+                                        if ($field_value === '') {
+                                            $field_value = '#000000';
+                                        }
+                                        ?>
+                                        <div class="color-field">
+                                            <label for="<?php echo esc_attr($field_id); ?>">
+                                                <?php echo esc_html($definition['label']); ?>
+                                            </label>
+                                            <div class="color-input-wrapper">
+                                                <input type="color"
+                                                       id="<?php echo esc_attr($field_id); ?>"
+                                                       name="yadore_shortcode_colors[<?php echo esc_attr($color_key); ?>]"
+                                                       value="<?php echo esc_attr($field_value); ?>"
+                                                       class="color-picker-input">
+                                                <input type="text" class="color-value-display" value="<?php echo esc_attr($field_value); ?>" readonly>
+                                            </div>
+                                            <?php if (!empty($definition['description'])) : ?>
+                                                <p class="form-description"><?php echo esc_html($definition['description']); ?></p>
+                                            <?php endif; ?>
+                                            <?php if (!empty($color_palette)) : ?>
+                                                <div class="color-palette-swatches" role="group" aria-label="<?php esc_attr_e('Available colors', 'yadore-monetizer'); ?>">
+                                                    <?php foreach ($color_palette as $palette_value => $palette_label) :
+                                                        $palette_value = (string) $palette_value;
+                                                        ?>
+                                                        <button type="button"
+                                                                class="color-swatch"
+                                                                data-target="<?php echo esc_attr($field_id); ?>"
+                                                                data-color="<?php echo esc_attr($palette_value); ?>"
+                                                                style="background-color: <?php echo esc_attr($palette_value); ?>;"
+                                                                title="<?php echo esc_attr($palette_label . ' (' . strtoupper($palette_value) . ')'); ?>">
+                                                            <span class="screen-reader-text"><?php echo esc_html($palette_label); ?></span>
+                                                        </button>
+                                                    <?php endforeach; ?>
+                                                </div>
+                                            <?php endif; ?>
+                                        </div>
+                                    <?php endforeach; ?>
+                                </div>
+                                <div class="color-settings-card">
+                                    <h4><?php esc_html_e('Overlay Template', 'yadore-monetizer'); ?></h4>
+                                    <?php foreach ($color_field_definitions as $color_key => $definition) :
+                                        $field_id = 'yadore_overlay_colors_' . $color_key;
+                                        $field_value = isset($overlay_colors[$color_key]) ? (string) $overlay_colors[$color_key] : '';
+                                        if ($field_value === '') {
+                                            $field_value = '#000000';
+                                        }
+                                        ?>
+                                        <div class="color-field">
+                                            <label for="<?php echo esc_attr($field_id); ?>">
+                                                <?php echo esc_html($definition['label']); ?>
+                                            </label>
+                                            <div class="color-input-wrapper">
+                                                <input type="color"
+                                                       id="<?php echo esc_attr($field_id); ?>"
+                                                       name="yadore_overlay_colors[<?php echo esc_attr($color_key); ?>]"
+                                                       value="<?php echo esc_attr($field_value); ?>"
+                                                       class="color-picker-input">
+                                                <input type="text" class="color-value-display" value="<?php echo esc_attr($field_value); ?>" readonly>
+                                            </div>
+                                            <?php if (!empty($definition['description'])) : ?>
+                                                <p class="form-description"><?php echo esc_html($definition['description']); ?></p>
+                                            <?php endif; ?>
+                                            <?php if (!empty($color_palette)) : ?>
+                                                <div class="color-palette-swatches" role="group" aria-label="<?php esc_attr_e('Available colors', 'yadore-monetizer'); ?>">
+                                                    <?php foreach ($color_palette as $palette_value => $palette_label) :
+                                                        $palette_value = (string) $palette_value;
+                                                        ?>
+                                                        <button type="button"
+                                                                class="color-swatch"
+                                                                data-target="<?php echo esc_attr($field_id); ?>"
+                                                                data-color="<?php echo esc_attr($palette_value); ?>"
+                                                                style="background-color: <?php echo esc_attr($palette_value); ?>;"
+                                                                title="<?php echo esc_attr($palette_label . ' (' . strtoupper($palette_value) . ')'); ?>">
+                                                            <span class="screen-reader-text"><?php echo esc_html($palette_label); ?></span>
+                                                        </button>
+                                                    <?php endforeach; ?>
+                                                </div>
+                                            <?php endif; ?>
+                                        </div>
+                                    <?php endforeach; ?>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -761,7 +916,7 @@ jQuery(document).ready(function($) {
     $('#test-gemini-api').on('click', yadoreTestGeminiApi);
     $('#test-yadore-api').on('click', yadoreTestYadoreApi);
 
-    console.log('Yadore Monetizer Pro v2.9.25 Settings - Initialized');
+    console.log('Yadore Monetizer Pro v2.9.26 Settings - Initialized');
 });
 
 function yadoreTestGeminiApi() {

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.9.25</span>
+        <span class="version-badge">v2.9.26</span>
     </h1>
 
     <div class="yadore-tools-container">
@@ -494,7 +494,7 @@ function yadoreInitializeTools() {
         yadoreHandleFileUpload(this.files);
     });
 
-    console.log('Yadore Tools v2.9.25 - Initialized');
+    console.log('Yadore Tools v2.9.26 - Initialized');
 }
 
 function yadoreLoadToolStats() {

--- a/templates/overlay-products-default.php
+++ b/templates/overlay-products-default.php
@@ -5,6 +5,13 @@ if (!defined('ABSPATH')) {
 
 $products = isset($products) && is_array($products) ? $products : array();
 $button_label = isset($button_label) ? (string) $button_label : __('Zum Angebot →', 'yadore-monetizer');
+$color_style = '';
+if (class_exists('YadoreMonetizer')) {
+    $instance = YadoreMonetizer::get_instance();
+    if ($instance instanceof YadoreMonetizer) {
+        $color_style = $instance->get_template_color_style('overlay');
+    }
+}
 
 if (empty($products)) :
     ?>
@@ -17,7 +24,7 @@ if (empty($products)) :
     return;
 endif;
 ?>
-<div class="overlay-products">
+<div class="overlay-products" <?php if ($color_style !== '') : ?>style="<?php echo esc_attr($color_style); ?>"<?php endif; ?>>
     <?php foreach ($products as $product) :
         $price_parts = yadore_get_formatted_price_parts($product['price'] ?? array());
         $price_amount = $price_parts['amount'] !== '' ? $price_parts['amount'] : 'N/A';
@@ -85,14 +92,15 @@ endif;
     gap: 20px;
     max-width: 420px;
     margin: 0 auto;
+    background-color: var(--yadore-background, transparent);
 }
 
 .overlay-product {
-    background: #f9f9f9;
+    background: var(--yadore-card-bg, #f9f9f9);
     border-radius: 12px;
     overflow: hidden;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
-    border: 1px solid #e9ecef;
+    border: 1px solid var(--yadore-border, #e9ecef);
     cursor: pointer;
 }
 
@@ -103,7 +111,7 @@ endif;
 
 .overlay-product:focus-within,
 .overlay-product:focus {
-    outline: 2px solid #3498db;
+    outline: 2px solid var(--yadore-primary, #3498db);
     outline-offset: 3px;
 }
 
@@ -120,12 +128,12 @@ endif;
 .overlay-product-image-placeholder {
     width: 100%;
     height: 160px;
-    background: #ecf0f1;
+    background: var(--yadore-placeholder, #ecf0f1);
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: 32px;
-    color: #95a5a6;
+    color: var(--yadore-placeholder-text, #95a5a6);
 }
 
 .overlay-product-content {
@@ -135,7 +143,7 @@ endif;
 .overlay-product-title {
     font-size: 16px;
     font-weight: 600;
-    color: #2c3e50;
+    color: var(--yadore-text, #2c3e50);
     margin: 0 0 10px 0;
     line-height: 1.4;
     display: -webkit-box;
@@ -151,20 +159,20 @@ endif;
 .overlay-price-amount {
     font-size: 20px;
     font-weight: 700;
-    color: #27ae60;
+    color: var(--yadore-accent, #27ae60);
 }
 
 .overlay-price-currency {
     font-size: 14px;
     font-weight: 600;
     margin-left: 6px;
-    color: #27ae60;
+    color: var(--yadore-accent, #27ae60);
     text-transform: uppercase;
 }
 
 .overlay-product-merchant {
     font-size: 13px;
-    color: #7f8c8d;
+    color: var(--yadore-muted, #7f8c8d);
     margin-bottom: 16px;
 }
 
@@ -172,8 +180,8 @@ endif;
     display: block;
     width: 100%;
     padding: 12px 16px;
-    background: linear-gradient(135deg, #3498db, #2980b9);
-    color: white;
+    background: linear-gradient(135deg, var(--yadore-primary-light, #5dade2), var(--yadore-primary-dark, #2980b9));
+    color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
     border-radius: 8px;
     font-weight: 600;
@@ -183,9 +191,9 @@ endif;
 }
 
 .overlay-product-button:hover {
-    background: linear-gradient(135deg, #2980b9, #21618c);
+    background: linear-gradient(135deg, var(--yadore-primary-dark, #2980b9), var(--yadore-primary-darker, #21618c));
     transform: translateY(-2px);
-    color: white;
+    color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
 }
 
@@ -193,8 +201,8 @@ endif;
     position: absolute;
     top: 12px;
     left: 12px;
-    background: rgba(52, 152, 219, 0.95);
-    color: #ffffff;
+    background: var(--yadore-badge-rgba, rgba(52, 152, 219, 0.95));
+    color: var(--yadore-badge-text, #ffffff);
     padding: 6px 10px;
     border-radius: 20px;
     font-size: 12px;

--- a/templates/products-grid.php
+++ b/templates/products-grid.php
@@ -1,4 +1,13 @@
-<div class="yadore-products-grid" data-format="grid">
+<?php
+$color_style = '';
+if (class_exists('YadoreMonetizer')) {
+    $instance = YadoreMonetizer::get_instance();
+    if ($instance instanceof YadoreMonetizer) {
+        $color_style = $instance->get_template_color_style('shortcode');
+    }
+}
+?>
+<div class="yadore-products-grid" data-format="grid" <?php if ($color_style !== '') : ?>style="<?php echo esc_attr($color_style); ?>"<?php endif; ?>>
     <?php if (!empty($offers)): ?>
         <?php foreach ($offers as $offer): ?>
             <?php

--- a/templates/products-inline.php
+++ b/templates/products-inline.php
@@ -1,4 +1,13 @@
-<div class="yadore-products-inline" data-format="inline">
+<?php
+$color_style = '';
+if (class_exists('YadoreMonetizer')) {
+    $instance = YadoreMonetizer::get_instance();
+    if ($instance instanceof YadoreMonetizer) {
+        $color_style = $instance->get_template_color_style('shortcode');
+    }
+}
+?>
+<div class="yadore-products-inline" data-format="inline" <?php if ($color_style !== '') : ?>style="<?php echo esc_attr($color_style); ?>"<?php endif; ?>>
     <div class="inline-header">
         <h3>Empfehlung</h3>
         <div class="inline-subtitle">

--- a/templates/products-list.php
+++ b/templates/products-list.php
@@ -1,4 +1,13 @@
-<div class="yadore-products-list" data-format="list">
+<?php
+$color_style = '';
+if (class_exists('YadoreMonetizer')) {
+    $instance = YadoreMonetizer::get_instance();
+    if ($instance instanceof YadoreMonetizer) {
+        $color_style = $instance->get_template_color_style('shortcode');
+    }
+}
+?>
+<div class="yadore-products-list" data-format="list" <?php if ($color_style !== '') : ?>style="<?php echo esc_attr($color_style); ?>"<?php endif; ?>>
     <?php if (!empty($offers)): ?>
         <?php foreach ($offers as $offer): ?>
             <?php


### PR DESCRIPTION
## Summary
- bump the plugin version to 2.9.26 across PHP, templates, assets and documentation
- add palette-driven color settings for shortcode and overlay templates with new sanitisation helpers and CSS variables
- refresh frontend/admin styling and README to document the new colour customisation features

## Testing
- php -l yadore-monetizer-pro/yadore-monetizer.php
- php -l yadore-monetizer-pro/templates/admin-settings.php
- php -l yadore-monetizer-pro/templates/overlay-products-default.php
- php -l yadore-monetizer-pro/templates/products-grid.php
- php -l yadore-monetizer-pro/templates/products-list.php
- php -l yadore-monetizer-pro/templates/products-inline.php

------
https://chatgpt.com/codex/tasks/task_e_68d21e762ec883258136bc28fced6d7a