### PR TITLE
Bump to v2.9.27 with Gemini 2.5 suite and dynamic dashboard versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Yadore Monetizer Pro v2.9.26 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.27 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.9.26 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.27 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features  
-✅ **AI Content Analysis** - Gemini 2.0 & 1.5 Model Support mit intelligenter Keyword-Erkennung
+✅ **AI Content Analysis** - Gemini 2.5 & Live Preview Model Support mit intelligenter Keyword-Erkennung
 ✅ **Advanced Analytics** - Umfassende Performance-Berichte und Statistiken  
 ✅ **Bulk Post Scanner** - Automatische Content-Analyse für alle Posts  
 ✅ **Product Overlay System** - Intelligente Produktempfehlungen mit Overlay  
@@ -16,13 +16,12 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **19 AJAX Endpoints** - Alle korrekt implementiert inkl. Cache-Tools & Diagnostics
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 2.9.26**
+## 🌟 **NEU IN VERSION 2.9.27**
 
-- ✅ **Palette-basierte Template-Farben** – Alle Overlay- und Shortcode-Layouts lassen sich jetzt direkt im Backend mit einer festen Farbpalette branden.
-- ✅ **Intuitive Farbwähler im Backend** – Hex-Werte, Vorschau und Palette-Swatches sorgen für konsistente Markenfarben ohne eigenes CSS.
-- ✅ **Globale CSS-Variablen** – Frontend-Templates nutzen dynamische Variablen für Buttons, Badges, Platzhalter und Dark-Mode-Anpassungen.
-- ✅ **Cache-Dashboard & Statistiken** – Telemetrie zu Cache-Größe, Einträgen und Hit-Rate bleibt erhalten und wurde auf Version 2.9.26 abgestimmt.
-- ✅ **Cache-AJAX-Endpunkte** – `yadore_get_tool_stats`, `yadore_clear_cache` und `yadore_analyze_cache` arbeiten weiterhin vollständig per AJAX.
+- ✅ **Gemini 2.5 Model Suite** – Flash, Pro, Flash Lite und Live Flash Preview stehen jetzt vollständig im Backend zur Verfügung.
+- ✅ **Aktualisierte AI-Presets** – Die Modell-Presets wurden auf die 2.5-Generation umgestellt und erleichtern die schnelle Auswahl.
+- ✅ **Dashboard Version Sync** – Alle Badges und Systemkarten laden die Plugin-Version automatisch aus dem Core.
+- ✅ **Version-aware Assets** – Admin- und Frontend-Skripte erhalten die aktuelle Versionsnummer über Localize Scripts für Logging & Debugging.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -69,7 +68,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.26:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.27:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -271,13 +270,13 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.9.26 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v2.9.27 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v2.9.26:**
-- 🎨 Palette-basierte Template-Farben – Branding für alle Overlay- und Shortcode-Layouts direkt aus dem Backend.
-- 🖌️ Farbpaletten & Hex-Ausgabe – Farbwähler mit Vorschau und Palette sorgen für konsistente Markenfarben ohne Custom-CSS.
-- 🌓 CSS-Variablen & Dark-Mode – Buttons, Badges und Platzhalter reagieren automatisch auf deine Palette und den Dark-Mode.
-- 📊 Cache-Dashboard & Telemetrie – Live-Statistiken zu Cache-Größe, Einträgen und Hit/Miss-Verhältnis bleiben auf 2.9.26 optimiert.
+### **Neue Highlights in v2.9.27:**
+- 🤖 Gemini 2.5 Flash & Pro – Höchste Performance und Qualität für deine AI-Analysen.
+- ⚡ Gemini 2.5 Flash Lite – Effiziente Variante für kostensensitive Automationen.
+- 📡 Gemini Live 2.5 Flash Preview – Live-Vorschau für interaktive Sessions.
+- 🧭 Dynamische Dashboard-Angaben – Versionen & Statusinformationen werden jetzt automatisch geladen.
 
 **Alle Features sind verfügbar und voll funktional!**
 
@@ -293,11 +292,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v2.9.26 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.27 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.9.26** - Production-Ready Market Release
+**Current Version: 2.9.27** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.26 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.27 - Admin CSS (Complete) */
 .yadore-admin-wrap {
     margin: 0;
 }

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.26 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.27 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.26 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.27 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: '2.9.26',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '2.9.27',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,
@@ -30,7 +30,7 @@
             this.initDebug();
             this.initErrorNotices();
 
-            console.log('Yadore Monetizer Pro v2.9.26 Admin - Fully Initialized');
+            console.log(`Yadore Monetizer Pro v${this.version} Admin - Fully Initialized`);
         },
 
         // Dashboard functionality

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.26 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.27 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: '2.9.26',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '2.9.27',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,
@@ -28,7 +28,7 @@
             this.initScrollTriggers();
             this.initResponsiveHandling();
 
-            console.log('Yadore Monetizer Pro v2.9.26 Frontend - Initialized');
+            console.log(`Yadore Monetizer Pro v${this.version} Frontend - Initialized`);
         },
 
         // Initialize product overlay

--- a/templates/admin-ai.php
+++ b/templates/admin-ai.php
@@ -1,16 +1,13 @@
 <?php
 $available_models = isset($gemini_models) && is_array($gemini_models) ? $gemini_models : array(
-    'gemini-2.0-flash' => array('label' => 'Gemini 2.0 Flash - Fastest'),
-    'gemini-2.0-flash-lite' => array('label' => 'Gemini 2.0 Flash Lite - Efficient'),
-    'gemini-2.0-pro-exp' => array('label' => 'Gemini 2.0 Pro (Experimental) - Highest quality'),
-    'gemini-2.0-flash-exp' => array('label' => 'Gemini 2.0 Flash (Experimental) - Latest features'),
-    'gemini-1.5-pro' => array('label' => 'Gemini 1.5 Pro - Most capable'),
-    'gemini-1.5-flash' => array('label' => 'Gemini 1.5 Flash - Balanced'),
-    'gemini-1.5-flash-8b' => array('label' => 'Gemini 1.5 Flash 8B - Lightweight'),
+    'gemini-2.5-flash' => array('label' => 'Gemini 2.5 Flash - Fastest next-gen'),
+    'gemini-2.5-pro' => array('label' => 'Gemini 2.5 Pro - Highest quality'),
+    'gemini-2.5-flash-lite' => array('label' => 'Gemini 2.5 Flash Lite - Efficient'),
+    'gemini-live-2.5-flash-preview' => array('label' => 'Gemini Live 2.5 Flash Preview - Live preview capabilities'),
 );
 $current_model = isset($selected_gemini_model)
     ? $selected_gemini_model
-    : get_option('yadore_gemini_model', 'gemini-2.0-flash');
+    : get_option('yadore_gemini_model', 'gemini-2.5-flash');
 $current_model_label = $available_models[$current_model]['label'] ?? $current_model;
 $ai_default_prompt = YadoreMonetizer::DEFAULT_AI_PROMPT;
 $ai_current_prompt = (string) get_option('yadore_ai_prompt', $ai_default_prompt);
@@ -22,7 +19,7 @@ if (trim($ai_current_prompt) === '') {
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-generic"></span>
         AI Management & Analysis
-        <span class="version-badge">v2.9.26</span>
+        <span class="version-badge">v<?php echo esc_html(YADORE_PLUGIN_VERSION); ?></span>
     </h1>
 
     <div class="yadore-ai-container">
@@ -376,7 +373,10 @@ function yadoreInitializeAiManagement() {
     $('#run-ai-test').on('click', yadoreRunAiTest);
     $('#run-batch-test').on('click', yadoreRunBatchTest);
 
-    console.log('Yadore AI Management v2.9.26 - Initialized');
+    const aiVersion = (typeof yadore_admin !== 'undefined' && yadore_admin.version)
+        ? yadore_admin.version
+        : '<?php echo esc_js(YADORE_PLUGIN_VERSION); ?>';
+    console.log(`Yadore AI Management v${aiVersion} - Initialized`);
 }
 
 function yadoreLoadAiStats() {

--- a/templates/admin-analytics.php
+++ b/templates/admin-analytics.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-chart-area"></span>
         Analytics & Performance Reports
-        <span class="version-badge">v2.9.26</span>
+        <span class="version-badge">v<?php echo esc_html(YADORE_PLUGIN_VERSION); ?></span>
     </h1>
 
     <div class="yadore-analytics-container">
@@ -319,7 +319,10 @@ function yadoreInitializeAnalytics() {
         yadoreLoadPerformanceTable($(this).val());
     });
 
-    console.log('Yadore Analytics v2.9.26 - Initialized');
+    const analyticsVersion = (typeof yadore_admin !== 'undefined' && yadore_admin.version)
+        ? yadore_admin.version
+        : '<?php echo esc_js(YADORE_PLUGIN_VERSION); ?>';
+    console.log(`Yadore Analytics v${analyticsVersion} - Initialized`);
 }
 
 function yadoreLoadAnalyticsData(period = 30) {

--- a/templates/admin-api-docs.php
+++ b/templates/admin-api-docs.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-media-document"></span>
         API Documentation & Monitoring
-        <span class="version-badge">v2.9.26</span>
+        <span class="version-badge">v<?php echo esc_html(YADORE_PLUGIN_VERSION); ?></span>
     </h1>
 
     <div class="yadore-api-container">
@@ -258,29 +258,24 @@ Accept: application/json</code></pre>
                                         <h4>Available Models</h4>
                                         <div class="models-list">
                                             <div class="model-item">
-                                                <h5>gemini-2.0-flash</h5>
-                                                <p>Fastest real-time model for production workloads</p>
+                                                <h5>gemini-2.5-flash</h5>
+                                                <p>Fastest 2.5 generation model for real-time product discovery</p>
                                                 <span class="model-badge recommended">Recommended</span>
                                             </div>
                                             <div class="model-item">
-                                                <h5>gemini-2.0-pro-exp</h5>
-                                                <p>Experimental pro model with the highest reasoning quality</p>
+                                                <h5>gemini-2.5-pro</h5>
+                                                <p>Highest quality reasoning for premium editorial automation</p>
                                                 <span class="model-badge premium">Premium</span>
                                             </div>
                                             <div class="model-item">
-                                                <h5>gemini-2.0-flash-lite</h5>
-                                                <p>Cost-efficient 2.0 model optimized for automation tasks</p>
+                                                <h5>gemini-2.5-flash-lite</h5>
+                                                <p>Cost-optimized 2.5 model balancing speed and efficiency</p>
                                                 <span class="model-badge standard">Efficient</span>
                                             </div>
                                             <div class="model-item">
-                                                <h5>gemini-1.5-flash-8b</h5>
-                                                <p>Lightweight option for quick content tagging and metadata</p>
-                                                <span class="model-badge standard">Lightweight</span>
-                                            </div>
-                                            <div class="model-item">
-                                                <h5>gemini-1.5-pro</h5>
-                                                <p>Highest accuracy for long-form editorial analysis</p>
-                                                <span class="model-badge premium">Advanced</span>
+                                                <h5>gemini-live-2.5-flash-preview</h5>
+                                                <p>Live preview variant enabling streaming-based interactions</p>
+                                                <span class="model-badge beta">Live Preview</span>
                                             </div>
                                         </div>
                                     </div>
@@ -465,7 +460,10 @@ function yadoreInitializeApiDocs() {
     $('#clear-logs').on('click', yadoreClearLogs);
     $('#export-logs').on('click', yadoreExportLogs);
 
-    console.log('Yadore API Documentation v2.9.26 - Initialized');
+    const docsVersion = (typeof yadore_admin !== 'undefined' && yadore_admin.version)
+        ? yadore_admin.version
+        : '<?php echo esc_js(YADORE_PLUGIN_VERSION); ?>';
+    console.log(`Yadore API Documentation v${docsVersion} - Initialized`);
 }
 
 function yadoreLoadApiStatus() {

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -2,12 +2,12 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-cart"></span>
         Yadore Monetizer Pro Dashboard
-        <span class="version-badge">v2.9.26</span>
+        <span class="version-badge">v<?php echo esc_html(YADORE_PLUGIN_VERSION); ?></span>
     </h1>
 
     <?php if (get_transient('yadore_activation_notice')): ?>
     <div class="notice notice-success is-dismissible">
-        <p><strong>Yadore Monetizer Pro v2.9.26 activated successfully!</strong> All features are now available.</p>
+        <p><strong>Yadore Monetizer Pro v<?php echo esc_html(YADORE_PLUGIN_VERSION); ?> activated successfully!</strong> All features are now available.</p>
     </div>
     <?php delete_transient('yadore_activation_notice'); endif; ?>
 
@@ -311,7 +311,7 @@
                             <div class="status-indicator status-active"></div>
                             <div class="status-details">
                                 <strong>WordPress Integration</strong>
-                                <small>v2.9.26 - All systems operational</small>
+                                <small><?php echo esc_html(sprintf('v%s - All systems operational', YADORE_PLUGIN_VERSION)); ?></small>
                             </div>
                         </div>
 
@@ -351,7 +351,7 @@
                     <div class="version-info">
                         <div class="info-row">
                             <span class="info-label">Plugin Version:</span>
-                            <span class="info-value version-current">v2.9.26</span>
+                            <span class="info-value version-current">v<?php echo esc_html(YADORE_PLUGIN_VERSION); ?></span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">WordPress:</span>
@@ -363,7 +363,7 @@
                         </div>
                         <div class="info-row">
                             <span class="info-label">Database:</span>
-                            <span class="info-value">Enhanced v2.9.26</span>
+                            <span class="info-value"><?php echo esc_html(sprintf('Enhanced v%s', YADORE_PLUGIN_VERSION)); ?></span>
                         </div>
                         <div class="info-row">
                             <span class="info-label">Features:</span>
@@ -419,7 +419,10 @@ jQuery(document).ready(function($) {
 });
 
 function yadoreInitializeDashboard() {
-    console.log('Yadore Monetizer Pro v2.9.26 Dashboard - Initialized');
+    const dashboardVersion = (typeof yadore_admin !== 'undefined' && yadore_admin.version)
+        ? yadore_admin.version
+        : '<?php echo esc_js(YADORE_PLUGIN_VERSION); ?>';
+    console.log(`Yadore Monetizer Pro v${dashboardVersion} Dashboard - Initialized`);
 }
 
 function yadoreLoadDashboardStats() {

--- a/templates/admin-debug.php
+++ b/templates/admin-debug.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Debug & Error Analysis
-        <span class="version-badge">v2.9.26</span>
+        <span class="version-badge">v<?php echo esc_html(YADORE_PLUGIN_VERSION); ?></span>
     </h1>
 
     <div class="yadore-debug-container">
@@ -223,7 +223,7 @@
                             <div class="info-items">
                                 <div class="info-item">
                                     <span class="info-label">Version:</span>
-                                    <span class="info-value">2.9.26</span>
+                                    <span class="info-value"><?php echo esc_html(YADORE_PLUGIN_VERSION); ?></span>
                                 </div>
                                 <div class="info-item">
                                     <span class="info-label">Debug Mode:</span>

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-search"></span>
         Post Scanner & Analysis
-        <span class="version-badge">v2.9.26</span>
+        <span class="version-badge">v<?php echo esc_html(YADORE_PLUGIN_VERSION); ?></span>
     </h1>
 
     <div class="yadore-scanner-container">

--- a/templates/admin-settings.php
+++ b/templates/admin-settings.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-settings"></span>
         Yadore Monetizer Pro Settings
-        <span class="version-badge">v2.9.26</span>
+        <span class="version-badge">v<?php echo esc_html(YADORE_PLUGIN_VERSION); ?></span>
     </h1>
 
     <?php
@@ -310,17 +310,14 @@
                                 <div class="model-selection">
                                     <?php
                                     $available_models = isset($gemini_models) && is_array($gemini_models) ? $gemini_models : array(
-                                        'gemini-2.0-flash' => array('label' => 'Gemini 2.0 Flash - Fastest'),
-                                        'gemini-2.0-flash-lite' => array('label' => 'Gemini 2.0 Flash Lite - Efficient'),
-                                        'gemini-2.0-pro-exp' => array('label' => 'Gemini 2.0 Pro (Experimental) - Highest quality'),
-                                        'gemini-2.0-flash-exp' => array('label' => 'Gemini 2.0 Flash (Experimental) - Latest features'),
-                                        'gemini-1.5-pro' => array('label' => 'Gemini 1.5 Pro - Most capable'),
-                                        'gemini-1.5-flash' => array('label' => 'Gemini 1.5 Flash - Balanced'),
-                                        'gemini-1.5-flash-8b' => array('label' => 'Gemini 1.5 Flash 8B - Lightweight'),
+                                        'gemini-2.5-flash' => array('label' => 'Gemini 2.5 Flash - Fastest next-gen'),
+                                        'gemini-2.5-pro' => array('label' => 'Gemini 2.5 Pro - Highest quality'),
+                                        'gemini-2.5-flash-lite' => array('label' => 'Gemini 2.5 Flash Lite - Efficient'),
+                                        'gemini-live-2.5-flash-preview' => array('label' => 'Gemini Live 2.5 Flash Preview - Live preview capabilities'),
                                     );
                                     $current_model = isset($selected_gemini_model)
                                         ? $selected_gemini_model
-                                        : get_option('yadore_gemini_model', 'gemini-2.0-flash');
+                                        : get_option('yadore_gemini_model', 'gemini-2.5-flash');
                                     ?>
                                     <select name="yadore_gemini_model" id="yadore_gemini_model" class="form-select">
                                         <?php foreach ($available_models as $model_key => $model_info) : ?>
@@ -331,10 +328,10 @@
                                     </select>
                                     <?php
                                     $preset_buttons = array(
-                                        'gemini-2.0-flash' => __('Flash 2.0', 'yadore-monetizer'),
-                                        'gemini-2.0-pro-exp' => __('Pro 2.0 (Exp)', 'yadore-monetizer'),
-                                        'gemini-1.5-pro' => __('1.5 Pro', 'yadore-monetizer'),
-                                        'gemini-1.5-flash-8b' => __('1.5 Flash 8B', 'yadore-monetizer'),
+                                        'gemini-2.5-flash' => __('Flash 2.5', 'yadore-monetizer'),
+                                        'gemini-2.5-pro' => __('Pro 2.5', 'yadore-monetizer'),
+                                        'gemini-2.5-flash-lite' => __('Flash Lite 2.5', 'yadore-monetizer'),
+                                        'gemini-live-2.5-flash-preview' => __('Live 2.5 Flash Preview', 'yadore-monetizer'),
                                     );
                                     ?>
                                     <div class="model-presets">
@@ -348,7 +345,7 @@
                                     </div>
                                 </div>
                                 <p class="form-description">
-                                    Choose from the latest Gemini models. Gemini 2.0 provides the newest capabilities, while Gemini 1.5 models balance performance and cost.
+                                    Choose from the latest Gemini 2.5 family. Flash is ideal for speed, Pro delivers the highest quality, Flash Lite optimizes for efficiency, and Live Flash Preview enables real-time interactions.
                                 </p>
                             </div>
 
@@ -916,7 +913,10 @@ jQuery(document).ready(function($) {
     $('#test-gemini-api').on('click', yadoreTestGeminiApi);
     $('#test-yadore-api').on('click', yadoreTestYadoreApi);
 
-    console.log('Yadore Monetizer Pro v2.9.26 Settings - Initialized');
+    const settingsVersion = (typeof yadore_admin !== 'undefined' && yadore_admin.version)
+        ? yadore_admin.version
+        : '<?php echo esc_js(YADORE_PLUGIN_VERSION); ?>';
+    console.log(`Yadore Monetizer Pro v${settingsVersion} Settings - Initialized`);
 });
 
 function yadoreTestGeminiApi() {

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -2,7 +2,7 @@
     <h1 class="yadore-page-title">
         <span class="dashicons dashicons-admin-tools"></span>
         Tools & Utilities
-        <span class="version-badge">v2.9.26</span>
+        <span class="version-badge">v<?php echo esc_html(YADORE_PLUGIN_VERSION); ?></span>
     </h1>
 
     <div class="yadore-tools-container">
@@ -494,7 +494,10 @@ function yadoreInitializeTools() {
         yadoreHandleFileUpload(this.files);
     });
 
-    console.log('Yadore Tools v2.9.26 - Initialized');
+    const toolsVersion = (typeof yadore_admin !== 'undefined' && yadore_admin.version)
+        ? yadore_admin.version
+        : '<?php echo esc_js(YADORE_PLUGIN_VERSION); ?>';
+    console.log(`Yadore Tools v${toolsVersion} - Initialized`);
 }
 
 function yadoreLoadToolStats() {

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 2.9.26
+Version: 2.9.27
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '2.9.26');
+define('YADORE_PLUGIN_VERSION', '2.9.27');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -107,7 +107,7 @@ class YadoreMonetizer {
             add_action('wp_dashboard_setup', array($this, 'add_dashboard_widgets'));
             add_action('admin_bar_menu', array($this, 'add_admin_bar_menu'), 999);
 
-            $this->log('Plugin v2.9.26 initialized successfully with complete feature set', 'info');
+            $this->log(sprintf('Plugin v%s initialized successfully with complete feature set', YADORE_PLUGIN_VERSION), 'info');
 
         } catch (Exception $e) {
             $this->log_error('Plugin initialization failed', $e, 'critical');
@@ -1440,6 +1440,7 @@ HTML
                     'limit' => get_option('yadore_overlay_limit', 3),
                     'auto_detection' => get_option('yadore_auto_detection', true),
                     'post_id' => get_queried_object_id(),
+                    'version' => YADORE_PLUGIN_VERSION,
                 ));
             }
 
@@ -6622,26 +6623,17 @@ $wpdb->insert($analytics_table, array(
 
     private function get_supported_gemini_models() {
         return array(
-            'gemini-2.0-flash' => array(
-                'label' => __('Gemini 2.0 Flash - Fastest', 'yadore-monetizer'),
+            'gemini-2.5-flash' => array(
+                'label' => __('Gemini 2.5 Flash - Fastest next-gen', 'yadore-monetizer'),
             ),
-            'gemini-2.0-flash-lite' => array(
-                'label' => __('Gemini 2.0 Flash Lite - Efficient', 'yadore-monetizer'),
+            'gemini-2.5-pro' => array(
+                'label' => __('Gemini 2.5 Pro - Highest quality', 'yadore-monetizer'),
             ),
-            'gemini-2.0-pro-exp' => array(
-                'label' => __('Gemini 2.0 Pro (Experimental) - Highest quality', 'yadore-monetizer'),
+            'gemini-2.5-flash-lite' => array(
+                'label' => __('Gemini 2.5 Flash Lite - Efficient', 'yadore-monetizer'),
             ),
-            'gemini-2.0-flash-exp' => array(
-                'label' => __('Gemini 2.0 Flash (Experimental) - Latest features', 'yadore-monetizer'),
-            ),
-            'gemini-1.5-pro' => array(
-                'label' => __('Gemini 1.5 Pro - Most capable', 'yadore-monetizer'),
-            ),
-            'gemini-1.5-flash' => array(
-                'label' => __('Gemini 1.5 Flash - Balanced', 'yadore-monetizer'),
-            ),
-            'gemini-1.5-flash-8b' => array(
-                'label' => __('Gemini 1.5 Flash 8B - Lightweight', 'yadore-monetizer'),
+            'gemini-live-2.5-flash-preview' => array(
+                'label' => __('Gemini Live 2.5 Flash Preview - Live preview capabilities', 'yadore-monetizer'),
             ),
         );
     }
@@ -6649,7 +6641,7 @@ $wpdb->insert($analytics_table, array(
     private function get_default_gemini_model() {
         $models = $this->get_supported_gemini_models();
         $first = array_key_first($models);
-        return $first ?: 'gemini-2.0-flash';
+        return $first ?: 'gemini-2.5-flash';
     }
 }
 


### PR DESCRIPTION
## Summary
- bump the plugin metadata and constant to version 2.9.27 and surface that value dynamically across the admin UI
- replace the legacy Gemini 2.0/1.5 model options with the Gemini 2.5 Flash, Pro, Flash Lite and Live Flash Preview offerings everywhere they are exposed
- inject the plugin version into localized scripts so dashboard, tools and logs automatically show the current release information, and refresh the README to document the new models

## Testing
- php -l yadore-monetizer.php
- php -l templates/admin-settings.php
- php -l templates/admin-ai.php
- php -l templates/admin-dashboard.php
- php -l templates/admin-tools.php
- php -l templates/admin-analytics.php
- php -l templates/admin-debug.php
- php -l templates/admin-api-docs.php
- php -l templates/admin-scanner.php

------
https://chatgpt.com/codex/tasks/task_e_68d227f1d1788325baeb7144afc545c4