### PR TITLE
Implement Yadore API click syncing and version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v2.9.32 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v2.9.33 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v2.9.32 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v2.9.33 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **6 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features
@@ -15,12 +15,12 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **22 AJAX Endpoints** - Alle korrekt implementiert inkl. Produktions-Diagnostik & Cache-Tools
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 2.9.32**
+## 🌟 **NEU IN VERSION 2.9.33**
 
-- ✅ **Stabilere Fehlerprotokollierung** – Fehler werden nur noch gespeichert, wenn die Log-Tabelle bereitsteht; fehlende Tabellen lösen keine Datenbankfehler mehr aus und Kontextdaten werden sicher kodiert.
-- ✅ **Zuverlässige Tabellenprüfungen** – Tabellenabfragen escapen Sonderzeichen und werden zwischengespeichert, wodurch Installationen mit individuellen Präfixen robuster arbeiten und unnötige Datenbankabfragen entfallen.
-- ✅ **Sichere Analytics-Aufzeichnung** – Tracking-Funktionen prüfen die Tabellenverfügbarkeit, bevor sie Daten speichern, und verwenden eine belastbare JSON-Kodierung für alle Ereignisdaten.
-- ✅ **Version Refresh** – Alle Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 2.9.32.
+- ✅ **Offizielles Click-Tracking** – Holt tägliche Daten über die Yadore Conversion Detail API, speichert eindeutige Click-IDs samt Händler- und Marktinformationen und füttert die Produkt-Analytics automatisch nach.
+- ✅ **AJAX-Endpunkt für Produktklicks** – Neue Frontend-Route `yadore_track_product_click` (inkl. Gastzugriff) persistiert Klicks mit Post-ID, URL und Session-Kontext, damit nichts verloren geht.
+- ✅ **Synchronisationsprotokoll** – Ein dediziertes `yadore_api_clicks`-Log vermeidet Duplikate, merkt sich Sync-Zeiten und stellt sicher, dass Dashboard und Reports immer die neuesten Klickzahlen zeigen.
+- ✅ **Version Refresh** – Alle Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 2.9.33.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -65,7 +65,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.32:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v2.9.33:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -270,13 +270,13 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v2.9.32 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v2.9.33 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v2.9.32:**
-- 🛡️ Verbesserte Fehlerlogs – Datenbankfehler werden vermieden, wenn Logging-Tabellen noch nicht angelegt sind, und Kontextdaten werden sicher gespeichert.
-- 📊 Präzisere Tabellenprüfungen – Escapete und gecachte LIKE-Abfragen sorgen für verlässliche Diagnosen auch bei individuellen Tabellenpräfixen.
-- 📈 Stabilere Analytics-Events – Tracking speichert Ereignisse nur bei vorhandenen Tabellen und nutzt robuste JSON-Kodierung.
-- 📦 Versionsupdate – Sämtliche Assets, Tooltips und Readme zeigen die aktuelle Release-Version 2.9.32.
+### **Neue Highlights in v2.9.33:**
+- 🖱️ Offizielles Click-Sync – Die Conversion Detail API liefert echte Klickdaten (inkl. Händler & Markt) direkt in das Analytics-Dashboard.
+- 🔄 Synchronisationslog – Eine neue `yadore_api_clicks`-Tabelle verhindert Duplikate und merkt sich, wann welche Tage bereits synchronisiert wurden.
+- 🌐 AJAX-Klicktracking – Der Endpoint `yadore_track_product_click` speichert Frontend-Klicks mit Post-Kontext und Session-ID für verlässliche Statistiken.
+- 📦 Versionsupdate – Sämtliche Assets, Tooltips und Readme zeigen die aktuelle Release-Version 2.9.33.
 
 **Alle Features sind verfügbar und voll funktional!**
 
@@ -292,11 +292,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v2.9.32 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v2.9.33 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 2.9.32** - Production-Ready Market Release
+**Current Version: 2.9.33** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.32 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.33 - Admin CSS (Complete) */
 .yadore-admin-wrap {
     margin: 0;
 }

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v2.9.32 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v2.9.33 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.32 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.33 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '2.9.32',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '2.9.33',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v2.9.32 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v2.9.33 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '2.9.32',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '2.9.33',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,
@@ -735,12 +735,15 @@
         trackProductClick: function(productId) {
             if (!productId) return;
 
-            $.post(this.settings.ajax_url, {
+            const payload = {
                 action: 'yadore_track_product_click',
                 nonce: this.settings.nonce,
                 product_id: productId,
-                page_url: window.location.href
-            }).done((response) => {
+                page_url: window.location.href,
+                post_id: this.settings.post_id || 0
+            };
+
+            $.post(this.settings.ajax_url, payload).done((response) => {
                 console.log('Yadore Monetizer: Product click tracked', productId);
             }).fail((error) => {
                 console.warn('Yadore Monetizer: Failed to track product click', error);


### PR DESCRIPTION
## Summary
- add a public `yadore_track_product_click` endpoint and supporting helpers to store clicks in analytics safely
- sync verified click data from Yadore's conversion detail API into a dedicated `yadore_api_clicks` table and reuse it inside dashboard/analytics builders
- bump the release to 2.9.33 and refresh documentation/assets so the new click tracking feature is documented

## Testing
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68d2ad21d4c0832596f024521a60bbb7