### PR TITLE
Add manual sidebar keyword controls and bump plugin version 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v3.1 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v3.2 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v3.1 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v3.2 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **6 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features
@@ -15,12 +15,13 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **22 AJAX Endpoints** - Alle korrekt implementiert inkl. Produktions-Diagnostik & Cache-Tools
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 3.1**
+## 🌟 **NEU IN VERSION 3.2**
 
+- ✅ **Manuelle Sidebar-Keywords** – Individuelle Primär- und Fallback-Keywords pro Beitrag oder Seite direkt in der Editor-Sidebar definieren – inklusive Validierung für automatische Platzierungen.
 - ✅ **Offizielles Click-Tracking** – Holt tägliche Daten über die Yadore Conversion Detail API, speichert eindeutige Click-IDs samt Händler- und Marktinformationen und füttert die Produkt-Analytics automatisch nach.
 - ✅ **AJAX-Endpunkt für Produktklicks** – Neue Frontend-Route `yadore_track_product_click` (inkl. Gastzugriff) persistiert Klicks mit Post-ID, URL und Session-Kontext, damit nichts verloren geht.
 - ✅ **Synchronisationsprotokoll** – Ein dediziertes `yadore_api_clicks`-Log vermeidet Duplikate, merkt sich Sync-Zeiten und stellt sicher, dass Dashboard und Reports immer die neuesten Klickzahlen zeigen.
-- ✅ **Version Refresh** – Alle Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 3.1.
+- ✅ **Version Refresh** – Alle Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 3.2.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -65,7 +66,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v3.1:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v3.2:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -270,13 +271,13 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v3.1 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v3.2 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v3.1:**
+### **Neue Highlights in v3.2:**
 - 🖱️ Offizielles Click-Sync – Die Conversion Detail API liefert echte Klickdaten (inkl. Händler & Markt) direkt in das Analytics-Dashboard.
 - 🔄 Synchronisationslog – Eine neue `yadore_api_clicks`-Tabelle verhindert Duplikate und merkt sich, wann welche Tage bereits synchronisiert wurden.
 - 🌐 AJAX-Klicktracking – Der Endpoint `yadore_track_product_click` speichert Frontend-Klicks mit Post-Kontext und Session-ID für verlässliche Statistiken.
-- 📦 Versionsupdate – Sämtliche Assets, Tooltips und Readme zeigen die aktuelle Release-Version 3.1.
+- 📦 Versionsupdate – Sämtliche Assets, Tooltips und Readme zeigen die aktuelle Release-Version 3.2.
 
 **Alle Features sind verfügbar und voll funktional!**
 
@@ -292,11 +293,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v3.1 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v3.2 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 3.1** - Production-Ready Market Release
+**Current Version: 3.2** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.1 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.2 - Admin CSS (Complete) */
 .yadore-admin-wrap {
     margin: 0;
 }

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.1 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v3.2 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.1 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.2 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.1',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.2',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.1 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.2 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.1',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.2',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/languages/yadore-monetizer-de_DE.po
+++ b/languages/yadore-monetizer-de_DE.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.1\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-24T06:11:31+00:00\n"
 "PO-Revision-Date: 2025-09-24T06:11:31+00:00\n"

--- a/languages/yadore-monetizer-en_US.po
+++ b/languages/yadore-monetizer-en_US.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.1\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-24T06:11:31+00:00\n"
 "PO-Revision-Date: 2025-09-24T06:11:31+00:00\n"

--- a/languages/yadore-monetizer.pot
+++ b/languages/yadore-monetizer.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.1\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## Summary
- bump the plugin version to 3.2 across the codebase, assets, and translation headers
- add a post/page sidebar meta box to capture manual primary and fallback keywords and persist them to the keyword table
- document the new manual keyword feature in the README alongside the updated release notes

## Testing
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68d7884b85188325869ea832da0e2796