### PR TITLE
Improve Gemini parsing and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v3.3 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v3.4 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v3.3 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v3.4 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **6 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features
@@ -15,13 +15,15 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **22 AJAX Endpoints** - Alle korrekt implementiert inkl. Produktions-Diagnostik & Cache-Tools
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 3.3**
+## 🌟 **NEU IN VERSION 3.4**
 
+- ✅ **Robustes Gemini-Parsing** – Verbesserte Verarbeitung der Google-Gemini-Antworten inkl. Schema-Normalisierung verhindert JSON-Fehler bei der Keyword-Ermittlung.
+- ✅ **Debug-Transparenz für Gemini** – Sämtliche Gemini-API-Fehler werden jetzt im Debug-Protokoll mit Kontext und Antwortdaten angezeigt.
 - ✅ **Manuelle Sidebar-Keywords** – Individuelle Primär- und Fallback-Keywords pro Beitrag oder Seite direkt in der Editor-Sidebar definieren – inklusive Validierung für automatische Platzierungen.
 - ✅ **Offizielles Click-Tracking** – Holt tägliche Daten über die Yadore Conversion Detail API, speichert eindeutige Click-IDs samt Händler- und Marktinformationen und füttert die Produkt-Analytics automatisch nach.
 - ✅ **AJAX-Endpunkt für Produktklicks** – Neue Frontend-Route `yadore_track_product_click` (inkl. Gastzugriff) persistiert Klicks mit Post-ID, URL und Session-Kontext, damit nichts verloren geht.
 - ✅ **Synchronisationsprotokoll** – Ein dediziertes `yadore_api_clicks`-Log vermeidet Duplikate, merkt sich Sync-Zeiten und stellt sicher, dass Dashboard und Reports immer die neuesten Klickzahlen zeigen.
-- ✅ **Version Refresh** – Alle Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 3.3.
+- ✅ **Version Refresh** – Alle Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 3.4.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -66,7 +68,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v3.3:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v3.4:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -271,13 +273,15 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v3.3 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v3.4 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v3.3:**
+### **Neue Highlights in v3.4:**
+- 🧠 Gemini JSON Guard – Verbesserte Schema-Normalisierung verhindert Parsing-Fehler und stellt stabile Keyword-Ergebnisse sicher.
+- 🛠️ Debug Insights – Das Debug-Panel listet jetzt alle Gemini-API-Fehler mit Zeitstempel, Endpoint und Antwortinhalt.
 - 🖱️ Offizielles Click-Sync – Die Conversion Detail API liefert echte Klickdaten (inkl. Händler & Markt) direkt in das Analytics-Dashboard.
 - 🔄 Synchronisationslog – Eine neue `yadore_api_clicks`-Tabelle verhindert Duplikate und merkt sich, wann welche Tage bereits synchronisiert wurden.
 - 🌐 AJAX-Klicktracking – Der Endpoint `yadore_track_product_click` speichert Frontend-Klicks mit Post-Kontext und Session-ID für verlässliche Statistiken.
-- 📦 Versionsupdate – Sämtliche Assets, Tooltips und Readme zeigen die aktuelle Release-Version 3.3.
+- 📦 Versionsupdate – Sämtliche Assets, Tooltips und Readme zeigen die aktuelle Release-Version 3.4.
 
 **Alle Features sind verfügbar und voll funktional!**
 
@@ -293,11 +297,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v3.3 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v3.4 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 3.3** - Production-Ready Market Release
+**Current Version: 3.4** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.3 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.4 - Admin CSS (Complete) */
 .yadore-admin-wrap {
     margin: 0;
 }

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.3 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v3.4 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.3 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.4 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.3',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.4',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,
@@ -2020,6 +2020,35 @@
                     return `${timestamp} ${severity} ${trace.error_message || ''}\n${trace.stack_trace || ''}`.trim();
                 });
                 sections.push('=== Recent Stack Traces ===\n' + traceLines.join('\n\n'));
+            }
+
+            if (Array.isArray(data.gemini_errors) && data.gemini_errors.length) {
+                const errorLines = data.gemini_errors.map((entry) => {
+                    const timestamp = entry.created_at ? `[${entry.created_at}]` : '';
+                    const endpoint = entry.endpoint ? `Endpoint: ${entry.endpoint}` : '';
+                    const message = entry.error_message || 'Gemini API error';
+                    let response = '';
+
+                    if (entry.response_body) {
+                        let formatted = entry.response_body;
+                        try {
+                            const parsed = JSON.parse(entry.response_body);
+                            formatted = JSON.stringify(parsed, null, 2);
+                        } catch (err) {
+                            formatted = entry.response_body;
+                        }
+
+                        response = `Response: ${formatted}`;
+                    }
+
+                    return [
+                        [timestamp, message].filter(Boolean).join(' ').trim(),
+                        endpoint,
+                        response
+                    ].filter(Boolean).join('\n');
+                });
+
+                sections.push('=== Gemini API Errors ===\n' + errorLines.join('\n\n'));
             }
 
             if (data.wp_debug_excerpt) {

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.3 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.4 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.3',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.4',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/languages/yadore-monetizer-de_DE.po
+++ b/languages/yadore-monetizer-de_DE.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.3\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-24T06:11:31+00:00\n"
 "PO-Revision-Date: 2025-09-24T06:11:31+00:00\n"

--- a/languages/yadore-monetizer-en_US.po
+++ b/languages/yadore-monetizer-en_US.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.3\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-24T06:11:31+00:00\n"
 "PO-Revision-Date: 2025-09-24T06:11:31+00:00\n"

--- a/languages/yadore-monetizer.pot
+++ b/languages/yadore-monetizer.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.3\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## Summary
- bump the plugin metadata, documentation, and assets to version 3.4
- harden Gemini API parsing with schema normalization, inline payload handling, and richer debug logging
- surface recent Gemini API failures in the Debug view for easier troubleshooting

## Testing
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68d7a63a794883258b56631d230f7f7c