### PR TITLE
Release 3.7 with template restore tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v3.6 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v3.7 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v3.6 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v3.7 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **6 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features
@@ -15,12 +15,13 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **22 AJAX Endpoints** - Alle korrekt implementiert inkl. Produktions-Diagnostik & Cache-Tools
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 3.6**
+## 🌟 **NEU IN VERSION 3.7**
 
+- ✅ **Wiederherstellbare Produkt-Templates** – Ein neues Tool stellt die vier Standard-Layouts per Klick wieder her und setzt auf Wunsch die Template-Auswahl zurück.
 - ✅ **Standard-Templates als Custom Posts** – Alle vier Frontend-Layouts werden automatisch angelegt, bleiben dauerhaft verfügbar und lassen sich direkt im WordPress-Editor bearbeiten.
 - ✅ **Gemini-Tokenlimit erhöht** – Der Standardwert für `maxOutputTokens` wurde auf 2000 angehoben, damit umfangreiche Antworten ohne Abschneiden verarbeitet werden können.
 - ✅ **Optimierter KI-Standardprompt** – Der Default-Prompt enthält jetzt explizite Variablen für `{title}` und `{content}` und liefert strukturierte Vorgaben für verlässliche Keyword-Ergebnisse.
-- ✅ **Version Refresh** – Alle Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 3.6.
+- ✅ **Version Refresh** – Alle Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 3.7.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -65,7 +66,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v3.6:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v3.7:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -270,13 +271,13 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v3.6 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v3.7 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v3.6:**
-- 🧱 Standard-Templates dauerhaft – Alle Standard-Layouts werden beim Aktivieren als Custom Posts angelegt und können jederzeit bearbeitet werden.
+### **Neue Highlights in v3.7:**
+- 🧱 Wiederherstellbare Standard-Templates – Neues Wartungs-Tool stellt die vier Default-Layouts inklusive Auswahloptionen per Klick wieder her.
 - 🧠 Gemini-Output ohne Limit – Das automatische Tokenlimit von 2000 verhindert abgeschnittene Antworten bei komplexen Analysen.
 - ✨ Prompt-Optimierung – Der Standardprompt nutzt `{title}` und `{content}` Platzhalter für zuverlässige Kontext-Übergabe an Gemini.
-- 📦 Versionsupdate – Sämtliche Assets, Tooltips und Readme zeigen die aktuelle Release-Version 3.6.
+- 📦 Versionsupdate – Sämtliche Assets, Tooltips und Readme zeigen die aktuelle Release-Version 3.7.
 
 **Alle Features sind verfügbar und voll funktional!**
 
@@ -292,11 +293,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v3.6 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v3.7 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 3.6** - Production-Ready Market Release
+**Current Version: 3.7** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.6 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.7 - Admin CSS (Complete) */
 .yadore-admin-wrap {
     margin: 0;
 }

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.6 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v3.7 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.6 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.7 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.6',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.7',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,
@@ -1599,6 +1599,12 @@
                 this.systemCleanup();
             });
 
+            $('#restore-default-templates').on('click', (e) => {
+                e.preventDefault();
+                const resetSelection = $('#restore-reset-selection').is(':checked');
+                this.restoreDefaultTemplates(resetSelection);
+            });
+
             // File upload handling
             $('#import-upload-area').on('click', () => {
                 $('#import-file').click();
@@ -1651,6 +1657,40 @@
                 }
             }).always(() => {
                 button.prop('disabled', false).html('<span class="dashicons dashicons-trash"></span> Clear Cache');
+            });
+        },
+
+        restoreDefaultTemplates: function(resetSelection) {
+            if (!confirm('Restore the default product templates? This will overwrite the built-in templates.')) {
+                return;
+            }
+
+            const button = $('#restore-default-templates');
+            const originalHtml = button.html();
+            button.prop('disabled', true).html('<span class="dashicons dashicons-update-alt spinning"></span> Restoring...');
+
+            $.post(this.ajax_url, {
+                action: 'yadore_restore_default_templates',
+                nonce: this.nonce,
+                reset_selection: resetSelection ? 1 : 0
+            }, (response) => {
+                if (response && response.success) {
+                    const data = response.data || {};
+                    const created = Number(data.created) || 0;
+                    const updated = Number(data.updated) || 0;
+                    const message = data.message || 'Templates restored successfully.';
+                    alert(`${message}\n${this.formatNumber(created)} created, ${this.formatNumber(updated)} updated.`);
+                    this.loadToolStats();
+                } else {
+                    const error = (response && response.data && response.data.message)
+                        ? response.data.message
+                        : 'Failed to restore templates.';
+                    alert(error);
+                }
+            }).fail(() => {
+                alert('Failed to restore templates.');
+            }).always(() => {
+                button.prop('disabled', false).html(originalHtml);
             });
         },
 

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.6 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.7 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.6',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.7',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/languages/yadore-monetizer-de_DE.po
+++ b/languages/yadore-monetizer-de_DE.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.6\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.7\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-24T06:11:31+00:00\n"
 "PO-Revision-Date: 2025-09-24T06:11:31+00:00\n"

--- a/languages/yadore-monetizer-en_US.po
+++ b/languages/yadore-monetizer-en_US.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.6\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.7\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-24T06:11:31+00:00\n"
 "PO-Revision-Date: 2025-09-24T06:11:31+00:00\n"

--- a/languages/yadore-monetizer.pot
+++ b/languages/yadore-monetizer.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.6\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.7\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/templates/admin-tools.php
+++ b/templates/admin-tools.php
@@ -287,6 +287,18 @@
                             </div>
 
                             <div class="reset-option">
+                                <h4>Restore Product Templates</h4>
+                                <p>Recreate the default product templates if they were removed or heavily modified.</p>
+                                <button class="button button-primary" id="restore-default-templates">
+                                    <span class="dashicons dashicons-layout"></span> Restore Templates
+                                </button>
+                                <label>
+                                    <input type="checkbox" id="restore-reset-selection">
+                                    <span>Reset template selection to defaults</span>
+                                </label>
+                            </div>
+
+                            <div class="reset-option">
                                 <h4>Clear All Data</h4>
                                 <p>Remove all plugin data including settings, logs, and cache. This cannot be undone.</p>
                                 <button class="button button-link-delete" id="clear-all-data">


### PR DESCRIPTION
## Summary
- bump the plugin version to 3.7 and refresh documentation plus asset headers
- add reusable helpers and an AJAX endpoint to recreate default product templates on demand
- expose a Tools screen control with JS handling to trigger template restoration from the admin

## Testing
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68d7b96e0a0c83258735b4b8438b384f