### PR TITLE
Bump version to 3.10 and refresh scanner analytics layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v3.9 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v3.10 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v3.9 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v3.10 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **6 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features
@@ -15,13 +15,14 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **22 AJAX Endpoints** - Alle korrekt implementiert inkl. Produktions-Diagnostik & Cache-Tools
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 3.9**
+## 🌟 **NEU IN VERSION 3.10**
 
 - ✅ **Überarbeitete Post-Scanner-Experience** – Neues Intro-Panel mit Best Practices, Quick-Tipps und klaren Highlights sorgt für einen transparenten Start in die Analyse.
+- 🎨 **Scan Analytics & Overview Refresh** – Mehr Abstand, nebeneinander angeordnete Kennzahlen und Panel-Design für eine klarere Interpretation der Ergebnisse.
 - ✅ **Aktive Scan-Zusammenfassung** – Unter dem Bulk Scanner zeigt eine Live-Zusammenfassung sofort, welche Post-Typen, Stati, Wortlimits und Zusatzoptionen ausgewählt sind.
 - ✅ **Schnellauswahl & Quick-Filter** – Selektiere Beitrags-Typen und Stati per Klick oder nutze die neuen Ergebnisfilter-Buttons (Alle, Erfolgreich, Fehlgeschlagen, AI genutzt) direkt in der Resultat-Liste.
 - ✅ **Status-Legende & Barrierefreiheit** – Eine farbcodierte Legende erklärt jeden Scanstatus, Quick-Filter erhalten ARIA-States und screenreader-freundliche Labels.
-- ✅ **Version Refresh** – Alle Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 3.9.
+- ✅ **Version Refresh** – Alle Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 3.10.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -66,7 +67,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v3.9:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v3.10:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -271,15 +272,15 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v3.9 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v3.10 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v3.9:**
+### **Neue Highlights in v3.10:**
 - 🎯 UX-Fokus – Überarbeitete Post-Scanner-Oberfläche mit Intro-Panel, Live-Zusammenfassung und Quick-Filtern.
 - 🧭 Orientierung auf einen Blick – Status-Legende, ARIA-optimierte Filterbuttons und ein zugängliches Scan-Dashboard erleichtern Reviews.
 - 🧱 Wiederherstellbare Standard-Templates – Neues Wartungs-Tool stellt die vier Default-Layouts inklusive Auswahloptionen per Klick wieder her.
 - 🧠 Gemini-Output ohne Limit – Das automatische Tokenlimit von 2000 verhindert abgeschnittene Antworten bei komplexen Analysen.
 - ✨ Prompt-Optimierung – Der Standardprompt nutzt `{title}` und `{content}` Platzhalter für zuverlässige Kontext-Übergabe an Gemini.
-- 📦 Versionsupdate – Sämtliche Assets, Tooltips und Readme zeigen die aktuelle Release-Version 3.9.
+- 📦 Versionsupdate – Sämtliche Assets, Tooltips und Readme zeigen die aktuelle Release-Version 3.10.
 
 **Alle Features sind verfügbar und voll funktional!**
 
@@ -295,11 +296,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v3.9 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v3.10 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 3.9** - Production-Ready Market Release
+**Current Version: 3.10** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.9 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.10 - Admin CSS (Complete) */
 .yadore-admin-wrap {
     margin: 0;
 }
@@ -512,14 +512,13 @@
 
 .overview-enhancements {
     display: grid;
-    gap: 18px;
-    margin-bottom: 24px;
+    gap: 22px;
 }
 
 .overview-meta {
     display: flex;
     flex-wrap: wrap;
-    gap: 12px;
+    gap: 16px;
     align-items: center;
 }
 
@@ -597,6 +596,25 @@
     overflow: hidden;
 }
 
+.overview-analytics-grid {
+    display: grid;
+    gap: 28px;
+    align-items: stretch;
+    margin-bottom: 32px;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.overview-analytics-grid .yadore-card {
+    height: 100%;
+}
+
+.scanner-overview .card-content {
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+    height: 100%;
+}
+
 .overview-progress-tracker .progress-fill {
     position: absolute;
     top: 0;
@@ -625,7 +643,87 @@
 .scanner-overview .scanner-stats {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 22px;
+}
+
+.scan-analytics-card .card-content {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    height: 100%;
+}
+
+.scan-analytics-card .analytics-grid {
+    display: grid;
+    gap: 24px;
+    grid-auto-rows: 1fr;
+}
+
+.scan-analytics-card .analytics-panel {
+    background: linear-gradient(135deg, #ffffff, #f7fbff);
+    border: 1px solid rgba(34, 113, 177, 0.12);
+    border-radius: 16px;
+    padding: 22px;
+    box-shadow: 0 12px 30px rgba(34, 113, 177, 0.08);
+    display: flex;
+    flex-direction: column;
     gap: 18px;
+    height: 100%;
+}
+
+.scan-analytics-card .analytics-panel h3 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: #135e96;
+}
+
+.scan-analytics-card .analytics-chart canvas {
+    width: 100% !important;
+    height: auto !important;
+}
+
+.scan-analytics-card .analytics-stats .stats-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.scan-analytics-card .analytics-stats .stat-label {
+    color: #475467;
+}
+
+.scan-analytics-card .analytics-stats .stat-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    font-size: 14px;
+    color: #1d2327;
+}
+
+.scan-analytics-card .analytics-stats .stat-value {
+    font-weight: 600;
+    color: #0f4d78;
+}
+
+@media (min-width: 960px) {
+    .scan-analytics-card .analytics-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .scan-analytics-card .analytics-stats {
+        grid-column: span 2;
+    }
+}
+
+@media (min-width: 1280px) {
+    .scan-analytics-card .analytics-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .scan-analytics-card .analytics-stats {
+        grid-column: auto;
+    }
 }
 
 .scanner-overview .stat-card {

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.9 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v3.10 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.9 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.10 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.9',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.10',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.9 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.10 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.9',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.10',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/languages/yadore-monetizer-de_DE.po
+++ b/languages/yadore-monetizer-de_DE.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.9\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.10\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-24T06:11:31+00:00\n"
 "PO-Revision-Date: 2025-09-24T06:11:31+00:00\n"

--- a/languages/yadore-monetizer-en_US.po
+++ b/languages/yadore-monetizer-en_US.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.9\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.10\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-24T06:11:31+00:00\n"
 "PO-Revision-Date: 2025-09-24T06:11:31+00:00\n"

--- a/languages/yadore-monetizer.pot
+++ b/languages/yadore-monetizer.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.9\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.10\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/templates/admin-scanner.php
+++ b/templates/admin-scanner.php
@@ -24,13 +24,14 @@
     </div>
 
     <div class="yadore-scanner-container">
-        <!-- Scanner Overview -->
-        <div class="yadore-card scanner-overview">
-            <div class="card-header">
-                <h2><span class="dashicons dashicons-dashboard"></span> Scanner Overview</h2>
-                <div class="card-actions">
-                    <button class="button button-secondary" id="refresh-overview">
-                        <span class="dashicons dashicons-update"></span> Refresh
+        <div class="overview-analytics-grid">
+            <!-- Scanner Overview -->
+            <div class="yadore-card scanner-overview">
+                <div class="card-header">
+                    <h2><span class="dashicons dashicons-dashboard"></span> Scanner Overview</h2>
+                    <div class="card-actions">
+                        <button class="button button-secondary" id="refresh-overview">
+                            <span class="dashicons dashicons-update"></span> Refresh
                     </button>
                 </div>
             </div>
@@ -116,6 +117,49 @@
                     <div class="progress-actions">
                         <button class="button button-secondary" id="pause-scan">Pause</button>
                         <button class="button button-link-delete" id="cancel-scan">Cancel</button>
+                    </div>
+                </div>
+            </div>
+            </div>
+
+            <!-- Scan Statistics -->
+            <div class="yadore-card scan-analytics-card">
+                <div class="card-header">
+                    <h2><span class="dashicons dashicons-chart-pie"></span> Scan Analytics</h2>
+                </div>
+                <div class="card-content">
+                    <div class="analytics-grid">
+                        <div class="analytics-panel analytics-chart">
+                            <h3>Keyword Categories</h3>
+                            <canvas id="keywords-chart" width="300" height="200"></canvas>
+                        </div>
+
+                        <div class="analytics-panel analytics-chart">
+                            <h3>Scan Success Rate</h3>
+                            <canvas id="success-chart" width="300" height="200"></canvas>
+                        </div>
+
+                        <div class="analytics-panel analytics-stats">
+                            <h3>Statistics</h3>
+                            <div class="stats-list">
+                                <div class="stat-row">
+                                    <span class="stat-label">Most Common Keyword:</span>
+                                    <span class="stat-value" id="top-keyword">Loading...</span>
+                                </div>
+                                <div class="stat-row">
+                                    <span class="stat-label">Average Confidence:</span>
+                                    <span class="stat-value" id="avg-confidence">Loading...</span>
+                                </div>
+                                <div class="stat-row">
+                                    <span class="stat-label">AI Usage Rate:</span>
+                                    <span class="stat-value" id="ai-usage-rate">Loading...</span>
+                                </div>
+                                <div class="stat-row">
+                                    <span class="stat-label">Success Rate:</span>
+                                    <span class="stat-value" id="scan-success-rate">Loading...</span>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -344,47 +388,6 @@
             </div>
         </div>
 
-        <!-- Scan Statistics -->
-        <div class="yadore-card">
-            <div class="card-header">
-                <h2><span class="dashicons dashicons-chart-pie"></span> Scan Analytics</h2>
-            </div>
-            <div class="card-content">
-                <div class="analytics-grid">
-                    <div class="analytics-chart">
-                        <h3>Keyword Categories</h3>
-                        <canvas id="keywords-chart" width="300" height="200"></canvas>
-                    </div>
-
-                    <div class="analytics-chart">
-                        <h3>Scan Success Rate</h3>
-                        <canvas id="success-chart" width="300" height="200"></canvas>
-                    </div>
-
-                    <div class="analytics-stats">
-                        <h3>Statistics</h3>
-                        <div class="stats-list">
-                            <div class="stat-row">
-                                <span class="stat-label">Most Common Keyword:</span>
-                                <span class="stat-value" id="top-keyword">Loading...</span>
-                            </div>
-                            <div class="stat-row">
-                                <span class="stat-label">Average Confidence:</span>
-                                <span class="stat-value" id="avg-confidence">Loading...</span>
-                            </div>
-                            <div class="stat-row">
-                                <span class="stat-label">AI Usage Rate:</span>
-                                <span class="stat-value" id="ai-usage-rate">Loading...</span>
-                            </div>
-                            <div class="stat-row">
-                                <span class="stat-label">Success Rate:</span>
-                                <span class="stat-value" id="scan-success-rate">Loading...</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
     </div>
 </div>
 

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.9
+Version: 3.10
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.9');
+define('YADORE_PLUGIN_VERSION', '3.10');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -2541,7 +2541,7 @@ HTML
 
             $this->reset_table_exists_cache();
 
-            $this->log('Enhanced database tables created successfully for v3.9', 'info');
+            $this->log('Enhanced database tables created successfully for v3.10', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Database table creation failed', $e, 'critical');


### PR DESCRIPTION
## Summary
- align the Scanner Overview and Scan Analytics cards side by side with refreshed spacing and panel styling for clearer analytics
- update the plugin version to 3.10 across code, documentation, and translation headers

## Testing
- php -l templates/admin-scanner.php
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68d7cf19f6548325a2e9207f59e2c7e0