### PR TITLE
chore: bump plugin version to 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v3.11 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v3.12 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v3.11 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v3.12 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **7 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features
@@ -15,14 +15,14 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **22 AJAX Endpoints** - Alle korrekt implementiert inkl. Produktions-Diagnostik & Cache-Tools
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 3.11**
+## 🌟 **NEU IN VERSION 3.12**
 
 - 🎨 **Design Tokens & CSS Layers** – Neues Stylesheet `assets/css/admin-design-system.css` definiert Farbspektren, Spacing-, Radius- und Shadow-Tokens (inkl. Dark-Mode) und strukturiert alle Admin-Styles via `@layer`.
 - 🧭 **Backend Styleguide Seite** – Frische Admin-Unterseite „Styleguide“ zeigt Farbrampen, Typografie-Skalen, Abstände sowie schlüsselfertige Komponenten inkl. Code-Beispielen und Copy-to-Clipboard.
 - 🧱 **Komponenten-Refactor** – `assets/css/admin.css` nutzt die neuen Tokens für Farben, Schatten und Abstände, wodurch künftige Optimierungen konsistent bleiben.
 - 🧰 **Clipboard Utility** – `assets/js/admin.js` enthält Copy-Feedback für Code-Snippets und Token-Vorschauen, inklusive Fallback für Browser ohne `navigator.clipboard`.
 - 📘 **Design-Dokumentation** – Neues Repository-Dokument `docs/STYLEGUIDE.md` beschreibt Prinzipien, Token-Änderungsprozesse und verweist auf relevante Dateien.
-- ✅ **Version Refresh** – Alle Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 3.11.
+- ✅ **Version Refresh** – Alle Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 3.12.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -68,7 +68,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v3.11:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v3.12:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -274,14 +274,14 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v3.11 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v3.12 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v3.11:**
+### **Neue Highlights in v3.12:**
 - 🎨 Design Tokens & Layered CSS – Farbspektren, Radius- und Spacing-Skalen sowie Schatten werden zentral gesteuert und in `assets/css/admin.css` genutzt.
 - 🧭 Admin Styleguide – Neue Unterseite „Styleguide“ mit Token-Vorschau, Komponentenbibliothek und Copy-to-Clipboard Buttons.
 - 🧰 Copy Workflow – `assets/js/admin.js` liefert ein modernes Clipboard-Feedback mit Fallback für ältere Browser.
 - 📘 Dokumentation – `docs/STYLEGUIDE.md` beschreibt Namenskonventionen, Governance und Abläufe für Designänderungen.
-- 📦 Versionsupdate – Sämtliche Assets, Tooltips und Readme zeigen die aktuelle Release-Version 3.11.
+- 📦 Versionsupdate – Sämtliche Assets, Tooltips und Readme zeigen die aktuelle Release-Version 3.12.
 
 **Alle Features sind verfügbar und voll funktional!**
 
@@ -297,11 +297,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v3.11 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v3.12 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 3.11** - Production-Ready Market Release
+**Current Version: 3.12** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin-design-system.css
+++ b/assets/css/admin-design-system.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.11 - Admin Design System Tokens */
+/* Yadore Monetizer Pro v3.12 - Admin Design System Tokens */
 @layer tokens {
     :root {
         color-scheme: light;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.11 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.12 - Admin CSS (Complete) */
 @layer base {
     .yadore-admin-wrap {
         margin: 0;

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.11 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v3.12 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.11 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.12 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.11',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.12',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.11 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.12 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.11',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.12',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -1,6 +1,6 @@
-# Yadore Monetizer Pro Design System (v3.11)
+# Yadore Monetizer Pro Design System (v3.12)
 
-Die Admin-Oberfläche von Yadore Monetizer Pro folgt ab Version 3.11 einem token-basierten Designsystem. Dieses Dokument dient als zentrale Referenz für Entwickler:innen, UX-Designer:innen und QA, um konsistente UI-Entscheidungen zu treffen und Änderungen nachvollziehbar zu dokumentieren.
+Die Admin-Oberfläche von Yadore Monetizer Pro folgt ab Version 3.12 einem token-basierten Designsystem. Dieses Dokument dient als zentrale Referenz für Entwickler:innen, UX-Designer:innen und QA, um konsistente UI-Entscheidungen zu treffen und Änderungen nachvollziehbar zu dokumentieren.
 
 ## 1. Architektur & Dateien
 

--- a/languages/yadore-monetizer-de_DE.po
+++ b/languages/yadore-monetizer-de_DE.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.11\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.12\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-24T06:11:31+00:00\n"
 "PO-Revision-Date: 2025-09-24T06:11:31+00:00\n"

--- a/languages/yadore-monetizer-en_US.po
+++ b/languages/yadore-monetizer-en_US.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.11\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.12\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-24T06:11:31+00:00\n"
 "PO-Revision-Date: 2025-09-24T06:11:31+00:00\n"

--- a/languages/yadore-monetizer.pot
+++ b/languages/yadore-monetizer.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.11\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.12\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.11
+Version: 3.12
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.11');
+define('YADORE_PLUGIN_VERSION', '3.12');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -1411,7 +1411,7 @@ HTML
                 array($this, 'admin_analytics_page')
             );
 
-            // v3.11: Design system styleguide
+            // v3.12: Design system styleguide
             add_submenu_page(
                 'yadore-monetizer',
                 'Design System & Styleguide',
@@ -2568,7 +2568,7 @@ HTML
 
             $this->reset_table_exists_cache();
 
-            $this->log('Enhanced database tables created successfully for v3.11', 'info');
+            $this->log('Enhanced database tables created successfully for v3.12', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Database table creation failed', $e, 'critical');


### PR DESCRIPTION
## Summary
- update the plugin header and runtime constant to version 3.12
- refresh all documentation, translations, and asset headers to match the new release number
- align admin and frontend scripts with the updated version fallback values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f2b0b560832591abf94cd7b03d47