### PR TITLE
Prefer main images and bump version to 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v3.12 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v3.13 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v3.12 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v3.13 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **7 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features
@@ -15,14 +15,14 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **22 AJAX Endpoints** - Alle korrekt implementiert inkl. Produktions-Diagnostik & Cache-Tools
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 3.12**
+## 🌟 **NEU IN VERSION 3.13**
 
 - 🎨 **Design Tokens & CSS Layers** – Neues Stylesheet `assets/css/admin-design-system.css` definiert Farbspektren, Spacing-, Radius- und Shadow-Tokens (inkl. Dark-Mode) und strukturiert alle Admin-Styles via `@layer`.
 - 🧭 **Backend Styleguide Seite** – Frische Admin-Unterseite „Styleguide“ zeigt Farbrampen, Typografie-Skalen, Abstände sowie schlüsselfertige Komponenten inkl. Code-Beispielen und Copy-to-Clipboard.
 - 🧱 **Komponenten-Refactor** – `assets/css/admin.css` nutzt die neuen Tokens für Farben, Schatten und Abstände, wodurch künftige Optimierungen konsistent bleiben.
 - 🧰 **Clipboard Utility** – `assets/js/admin.js` enthält Copy-Feedback für Code-Snippets und Token-Vorschauen, inklusive Fallback für Browser ohne `navigator.clipboard`.
 - 📘 **Design-Dokumentation** – Neues Repository-Dokument `docs/STYLEGUIDE.md` beschreibt Prinzipien, Token-Änderungsprozesse und verweist auf relevante Dateien.
-- ✅ **Version Refresh** – Alle Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 3.12.
+- ✅ **Version Refresh** – Alle Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 3.13.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -68,7 +68,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v3.12:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v3.13:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -274,14 +274,15 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v3.12 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v3.13 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v3.12:**
+### **Neue Highlights in v3.13:**
 - 🎨 Design Tokens & Layered CSS – Farbspektren, Radius- und Spacing-Skalen sowie Schatten werden zentral gesteuert und in `assets/css/admin.css` genutzt.
 - 🧭 Admin Styleguide – Neue Unterseite „Styleguide“ mit Token-Vorschau, Komponentenbibliothek und Copy-to-Clipboard Buttons.
 - 🧰 Copy Workflow – `assets/js/admin.js` liefert ein modernes Clipboard-Feedback mit Fallback für ältere Browser.
 - 📘 Dokumentation – `docs/STYLEGUIDE.md` beschreibt Namenskonventionen, Governance und Abläufe für Designänderungen.
-- 📦 Versionsupdate – Sämtliche Assets, Tooltips und Readme zeigen die aktuelle Release-Version 3.12.
+- 🖼️ Bildqualität – Produkt-Listings priorisieren jetzt immer das hochauflösende Hauptbild statt des Thumbnails.
+- 📦 Versionsupdate – Sämtliche Assets, Tooltips und Readme zeigen die aktuelle Release-Version 3.13.
 
 **Alle Features sind verfügbar und voll funktional!**
 
@@ -297,11 +298,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v3.12 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v3.13 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 3.12** - Production-Ready Market Release
+**Current Version: 3.13** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin-design-system.css
+++ b/assets/css/admin-design-system.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.12 - Admin Design System Tokens */
+/* Yadore Monetizer Pro v3.13 - Admin Design System Tokens */
 @layer tokens {
     :root {
         color-scheme: light;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.12 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.13 - Admin CSS (Complete) */
 @layer base {
     .yadore-admin-wrap {
         margin: 0;

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.12 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v3.13 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.12 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.13 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.12',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.13',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.12 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.13 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.12',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.13',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,
@@ -479,7 +479,7 @@
             const sanitize = (value) => $('<div/>').text(value || '').html();
 
             displayProducts.forEach((product) => {
-                const imageUrl = product.thumbnail?.url || product.image?.url || '';
+                const imageUrl = product.image?.url || product.thumbnail?.url || '';
                 const productId = sanitize(product.id || '');
                 const clickUrlRaw = product.clickUrl || '#';
                 const clickUrl = sanitize(clickUrlRaw);

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -1,6 +1,6 @@
-# Yadore Monetizer Pro Design System (v3.12)
+# Yadore Monetizer Pro Design System (v3.13)
 
-Die Admin-Oberfläche von Yadore Monetizer Pro folgt ab Version 3.12 einem token-basierten Designsystem. Dieses Dokument dient als zentrale Referenz für Entwickler:innen, UX-Designer:innen und QA, um konsistente UI-Entscheidungen zu treffen und Änderungen nachvollziehbar zu dokumentieren.
+Die Admin-Oberfläche von Yadore Monetizer Pro folgt ab Version 3.13 einem token-basierten Designsystem. Dieses Dokument dient als zentrale Referenz für Entwickler:innen, UX-Designer:innen und QA, um konsistente UI-Entscheidungen zu treffen und Änderungen nachvollziehbar zu dokumentieren.
 
 ## 1. Architektur & Dateien
 

--- a/languages/yadore-monetizer-de_DE.po
+++ b/languages/yadore-monetizer-de_DE.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.12\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.13\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-24T06:11:31+00:00\n"
 "PO-Revision-Date: 2025-09-24T06:11:31+00:00\n"

--- a/languages/yadore-monetizer-en_US.po
+++ b/languages/yadore-monetizer-en_US.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.12\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.13\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-24T06:11:31+00:00\n"
 "PO-Revision-Date: 2025-09-24T06:11:31+00:00\n"

--- a/languages/yadore-monetizer.pot
+++ b/languages/yadore-monetizer.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.12\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.13\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/templates/overlay-products-default.php
+++ b/templates/overlay-products-default.php
@@ -40,10 +40,10 @@ endif;
         $promo_text = esc_html($product['promoText'] ?? '');
 
         $image_url = '';
-        if (!empty($product['thumbnail']['url'])) {
-            $image_url = esc_url($product['thumbnail']['url']);
-        } elseif (!empty($product['image']['url'])) {
+        if (!empty($product['image']['url'])) {
             $image_url = esc_url($product['image']['url']);
+        } elseif (!empty($product['thumbnail']['url'])) {
+            $image_url = esc_url($product['thumbnail']['url']);
         }
         ?>
         <div class="overlay-product"

--- a/templates/products-grid.php
+++ b/templates/products-grid.php
@@ -26,7 +26,7 @@ if (class_exists('YadoreMonetizer')) {
                  tabindex="0">
                 <div class="product-image">
                     <?php
-                    $image_url = $offer['thumbnail']['url'] ?? $offer['image']['url'] ?? '';
+                    $image_url = $offer['image']['url'] ?? $offer['thumbnail']['url'] ?? '';
                     if (!empty($image_url)) :
                     ?>
                         <img src="<?php echo esc_url($image_url); ?>"

--- a/templates/products-inline.php
+++ b/templates/products-inline.php
@@ -38,7 +38,7 @@ if (class_exists('YadoreMonetizer')) {
                      tabindex="0">
                     <div class="inline-image">
                         <?php
-                        $image_url = $offer['thumbnail']['url'] ?? $offer['image']['url'] ?? '';
+                        $image_url = $offer['image']['url'] ?? $offer['thumbnail']['url'] ?? '';
                         if (!empty($image_url)) :
                         ?>
                             <img src="<?php echo esc_url($image_url); ?>"

--- a/templates/products-list.php
+++ b/templates/products-list.php
@@ -26,7 +26,7 @@ if (class_exists('YadoreMonetizer')) {
                  tabindex="0">
                 <div class="product-image">
                     <?php
-                    $image_url = $offer['thumbnail']['url'] ?? $offer['image']['url'] ?? '';
+                    $image_url = $offer['image']['url'] ?? $offer['thumbnail']['url'] ?? '';
                     if (!empty($image_url)) :
                     ?>
                         <img src="<?php echo esc_url($image_url); ?>"

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.12
+Version: 3.13
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.12');
+define('YADORE_PLUGIN_VERSION', '3.13');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -2568,7 +2568,7 @@ HTML
 
             $this->reset_table_exists_cache();
 
-            $this->log('Enhanced database tables created successfully for v3.12', 'info');
+            $this->log('Enhanced database tables created successfully for v3.13', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Database table creation failed', $e, 'critical');
@@ -3650,12 +3650,6 @@ HTML
             $sanitized['merchant']['name'] = sanitize_text_field((string) $product['merchantName']);
         }
 
-        if (isset($product['thumbnail']) && is_array($product['thumbnail'])) {
-            $sanitized['thumbnail']['url'] = isset($product['thumbnail']['url'])
-                ? esc_url_raw($product['thumbnail']['url'])
-                : '';
-        }
-
         if (isset($product['image']) && is_array($product['image'])) {
             $sanitized['image']['url'] = isset($product['image']['url'])
                 ? esc_url_raw($product['image']['url'])
@@ -3668,6 +3662,12 @@ HTML
             $sanitized['image'] = array('url' => esc_url_raw($product['imageUrl']));
         } elseif (isset($product['imageUrls']) && is_array($product['imageUrls']) && !empty($product['imageUrls'][0])) {
             $sanitized['image'] = array('url' => esc_url_raw($product['imageUrls'][0]));
+        }
+
+        if (isset($product['thumbnail']) && is_array($product['thumbnail'])) {
+            $sanitized['thumbnail']['url'] = isset($product['thumbnail']['url'])
+                ? esc_url_raw($product['thumbnail']['url'])
+                : '';
         }
 
         if (isset($product['clickUrl'])) {
@@ -3694,6 +3694,10 @@ HTML
 
         if (isset($product['promoText'])) {
             $sanitized['promoText'] = sanitize_text_field((string) $product['promoText']);
+        }
+
+        if (empty($sanitized['image']['url']) && !empty($sanitized['thumbnail']['url'])) {
+            $sanitized['image']['url'] = $sanitized['thumbnail']['url'];
         }
 
         if (empty($sanitized['thumbnail']['url']) && !empty($sanitized['image']['url'])) {
@@ -8280,10 +8284,10 @@ HTML
         $click_url = esc_url($click_url_raw !== '' ? $click_url_raw : '#');
 
         $image_url_raw = '';
-        if (isset($product['thumbnail']['url']) && $product['thumbnail']['url'] !== '') {
-            $image_url_raw = (string) $product['thumbnail']['url'];
-        } elseif (isset($product['image']['url']) && $product['image']['url'] !== '') {
+        if (isset($product['image']['url']) && $product['image']['url'] !== '') {
             $image_url_raw = (string) $product['image']['url'];
+        } elseif (isset($product['thumbnail']['url']) && $product['thumbnail']['url'] !== '') {
+            $image_url_raw = (string) $product['thumbnail']['url'];
         }
         $image_url = esc_url($image_url_raw);
 


### PR DESCRIPTION
## Summary
- prefer the primary image URL when rendering offers across frontend templates, overlay rendering, and template placeholder logic
- ensure sanitized product data backfills missing image URLs from thumbnails while still exposing thumbnails as fallbacks
- bump the plugin release version to 3.13 throughout metadata, assets, documentation, and translation headers

## Testing
- php -l yadore-monetizer.php
- php -l templates/overlay-products-default.php
- php -l templates/products-grid.php
- php -l templates/products-inline.php
- php -l templates/products-list.php

------
https://chatgpt.com/codex/tasks/task_e_68d7fa46e95883258c4a0127b9f2e6e1