### PR TITLE
Add onboarding checklist UX and bump plugin to 3.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v3.14 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v3.16 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v3.14 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v3.16 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **7 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features
@@ -15,12 +15,13 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **22 AJAX Endpoints** - Alle korrekt implementiert inkl. Produktions-Diagnostik & Cache-Tools
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 3.14**
+## 🌟 **NEU IN VERSION 3.16**
 
-- 📊 **Analytics & Leistungsberichte Redesign** – Die komplette Admin-Seite „Analysen & Leistungsberichte" nutzt nun das tokenbasierte Grid-Layout inklusive responsiver Karten, klar strukturierter Tabellen und harmonisierter Abstände.
-- 🎯 **Trend- & Kennzahlen-Badges** – Stat Cards, Metrik-Zeilen und Trendlabels folgen der Design-Sprache aus dem Styleguide (Tokens für Farben, Typografie, Spacing & Motion).
-- 🧭 **Styleguide Alignment** – Karten, Kopfbereiche und Aktionsleisten wurden repository-weit auf das neue Komponentensystem gehoben und profitieren von konsistenten Tokens.
-- ✅ **Version Refresh** – Alle Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 3.14.
+- ✅ **Schnellstart-Checkliste & Fortschrittsanzeige** – Das Dashboard bietet jetzt eine geführte Onboarding-Karte inklusive Prozentanzeige und Statusbadges, damit neue Installationen keine Pflichtschritte übersehen.
+- 🧭 **Geführte Setup-Aktionen** – Jede Checklisten-Kachel enthält kontextuelle Call-to-Actions zu den relevanten Admin-Seiten (Einstellungen, Analytics), wodurch Konfigurationen mit einem Klick erreichbar sind.
+- 🔔 **Kontextuelle Status-Hinweise** – Der Systemstatus zeigt bei fehlenden API-Keys nun direkte Links zum Setup und reduziert so Reibung beim Troubleshooting.
+- 🎨 **UI-Polish & Mikrointeraktionen** – Neue Motion- und Hover-States für Checklisten-Elemente, optimierte Progress-Balken und zugängliche Farbkontraste verbessern das Nutzererlebnis spürbar.
+- ♻️ **Version Refresh** – Alle Assets, Überschriften und Dokumentationen reflektieren die aktuelle Release-Version 3.16.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -66,7 +67,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v3.14:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v3.16:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -272,15 +273,14 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v3.14 - PRODUCTION-READY MARKET RELEASE!**
+## 🎉 **v3.16 - PRODUCTION-READY MARKET RELEASE!**
 
-### **Neue Highlights in v3.14:**
-- 🎨 Design Tokens & Layered CSS – Farbspektren, Radius- und Spacing-Skalen sowie Schatten werden zentral gesteuert und in `assets/css/admin.css` genutzt.
-- 🧭 Admin Styleguide – Neue Unterseite „Styleguide“ mit Token-Vorschau, Komponentenbibliothek und Copy-to-Clipboard Buttons.
-- 🧰 Copy Workflow – `assets/js/admin.js` liefert ein modernes Clipboard-Feedback mit Fallback für ältere Browser.
-- 📘 Dokumentation – `docs/STYLEGUIDE.md` beschreibt Namenskonventionen, Governance und Abläufe für Designänderungen.
-- 🖼️ Bildqualität – Produkt-Listings priorisieren jetzt immer das hochauflösende Hauptbild statt des Thumbnails.
-- 📦 Versionsupdate – Sämtliche Assets, Tooltips und Readme zeigen die aktuelle Release-Version 3.14.
+### **Neue Highlights in v3.16:**
+- ✅ **Dashboard-Checkliste** – Neue Onboarding-Karte im Dashboard zeigt alle wichtigen Aktivierungsschritte inklusive Fortschrittsanzeige und Status-Tags.
+- 🔗 **Direkte Setup-Aktionen** – Jede Checklist-Kachel verlinkt zu den passenden Einstellungen (API, Automatisierung, Analytics) für ein nahtloses Setup.
+- 🔔 **Verbesserter Systemstatus** – Fehlende API- oder KI-Schlüssel werden jetzt mit klaren Warnfarben und Inline-Links zur Konfiguration hervorgehoben.
+- ✨ **Verfeinerte UX-Details** – Animierte Fortschrittsbalken, Hover-Zustände und kontrastreiche Buttons sorgen für mehr Klarheit und Feedback.
+- 📦 **Versionsupdate** – Sämtliche Assets, Tooltips und Dokumentation tragen die aktuelle Release-Version 3.16.
 
 **Alle Features sind verfügbar und voll funktional!**
 
@@ -296,11 +296,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v3.14 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v3.16 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 3.14** - Production-Ready Market Release
+**Current Version: 3.16** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin-design-system.css
+++ b/assets/css/admin-design-system.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.14 - Admin Design System Tokens */
+/* Yadore Monetizer Pro v3.16 - Admin Design System Tokens */
 @layer tokens {
     :root {
         color-scheme: light;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.14 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.16 - Admin CSS (Complete) */
 @layer base {
     .yadore-admin-wrap {
         margin: 0;
@@ -690,6 +690,169 @@
     min-width: 0;
 }
 
+.yadore-onboarding-card .card-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--yadore-space-5);
+}
+
+.onboarding-progress {
+    display: grid;
+    gap: var(--yadore-space-3);
+    padding: var(--yadore-space-4);
+    border-radius: var(--yadore-radius-md);
+    border: 1px solid var(--yadore-border-subtle);
+    background: var(--yadore-color-surface-muted);
+}
+
+.progress-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--yadore-space-3);
+    font-weight: var(--yadore-font-weight-medium);
+    color: var(--yadore-color-neutral-900);
+}
+
+.progress-label {
+    font-size: var(--yadore-font-size-sm);
+    color: var(--yadore-color-neutral-600);
+}
+
+.progress-value {
+    font-size: var(--yadore-font-size-lg);
+    font-weight: var(--yadore-font-weight-semibold);
+    color: var(--yadore-color-primary-500);
+}
+
+.progress-bar {
+    position: relative;
+    height: 8px;
+    border-radius: var(--yadore-radius-pill);
+    background: var(--yadore-border-subtle);
+    overflow: hidden;
+}
+
+.progress-bar-fill {
+    position: absolute;
+    inset: 0;
+    width: var(--progress, 0%);
+    background: var(--yadore-gradient-primary);
+    transition: width var(--yadore-motion-duration-fast) var(--yadore-motion-easing-standard);
+}
+
+.progress-message {
+    margin: 0;
+    font-size: var(--yadore-font-size-sm);
+    color: var(--yadore-color-neutral-600);
+}
+
+.progress-message.success {
+    color: var(--yadore-color-success-700);
+    font-weight: var(--yadore-font-weight-medium);
+}
+
+.onboarding-checklist {
+    display: flex;
+    flex-direction: column;
+    gap: var(--yadore-space-3);
+}
+
+.checklist-item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: var(--yadore-space-3);
+    padding: var(--yadore-space-4);
+    border: 1px solid var(--yadore-border-subtle);
+    border-radius: var(--yadore-radius-md);
+    background: var(--yadore-color-surface);
+    align-items: flex-start;
+    transition: border-color var(--yadore-motion-duration-fast) var(--yadore-motion-easing-standard),
+        box-shadow var(--yadore-motion-duration-fast) var(--yadore-motion-easing-standard),
+        transform var(--yadore-motion-duration-fast) var(--yadore-motion-easing-standard);
+}
+
+.checklist-item:hover {
+    border-color: var(--yadore-color-primary-400);
+    box-shadow: var(--yadore-shadow-sm);
+    transform: translateY(-1px);
+}
+
+.checklist-item.is-complete {
+    border-color: rgba(0, 163, 42, 0.35);
+    background: var(--yadore-color-success-100);
+    background: color-mix(in srgb, var(--yadore-color-success-100) 60%, #ffffff 40%);
+}
+
+.checklist-item.is-pending {
+    border-style: dashed;
+}
+
+.checklist-icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--yadore-color-surface-strong);
+    color: var(--yadore-color-primary-500);
+    font-size: 18px;
+}
+
+.checklist-item.is-complete .checklist-icon {
+    background: var(--yadore-color-success-100);
+    color: var(--yadore-color-success-700);
+}
+
+.checklist-content {
+    display: grid;
+    gap: var(--yadore-space-2);
+}
+
+.checklist-content strong {
+    font-size: var(--yadore-font-size-sm);
+    color: var(--yadore-color-neutral-900);
+}
+
+.checklist-content p {
+    margin: 0;
+    font-size: var(--yadore-font-size-sm);
+    color: var(--yadore-color-neutral-600);
+}
+
+.checklist-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--yadore-space-2);
+}
+
+.button-link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--yadore-space-1);
+    font-size: var(--yadore-font-size-sm);
+    font-weight: var(--yadore-font-weight-semibold);
+    color: var(--yadore-color-primary-500);
+    text-decoration: none;
+}
+
+.button-link::after {
+    content: '\2192';
+    font-size: 14px;
+    line-height: 1;
+    transition: transform var(--yadore-motion-duration-fast) var(--yadore-motion-easing-standard);
+}
+
+.button-link:hover {
+    color: var(--yadore-color-primary-600);
+}
+
+.button-link:hover::after {
+    transform: translateX(2px);
+}
+
 /* Stats Grid */
 .yadore-stats-grid {
     display: grid;
@@ -1314,6 +1477,11 @@
 .status-badge.status-inactive {
     background: #f8d7da;
     color: #721c24;
+}
+
+.status-badge.status-warning {
+    background: #fff4ce;
+    color: #8a6d1a;
 }
 
 /* Shortcode Generator */

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.14 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v3.16 - Frontend CSS (Complete) */
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.14 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.16 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.14',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.16',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.14 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.16 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.14',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.16',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -1,6 +1,6 @@
-# Yadore Monetizer Pro Design System (v3.14)
+# Yadore Monetizer Pro Design System (v3.16)
 
-Die Admin-Oberfläche von Yadore Monetizer Pro folgt ab Version 3.14 einem token-basierten Designsystem. Dieses Dokument dient als zentrale Referenz für Entwickler:innen, UX-Designer:innen und QA, um konsistente UI-Entscheidungen zu treffen und Änderungen nachvollziehbar zu dokumentieren.
+Die Admin-Oberfläche von Yadore Monetizer Pro folgt ab Version 3.16 einem token-basierten Designsystem. Dieses Dokument dient als zentrale Referenz für Entwickler:innen, UX-Designer:innen und QA, um konsistente UI-Entscheidungen zu treffen und Änderungen nachvollziehbar zu dokumentieren.
 
 ## 1. Architektur & Dateien
 
@@ -43,6 +43,7 @@ Die Styleguide-Seite (`templates/admin-styleguide.php`) zeigt Referenz-HTML für
 - **Stat Cards** (`.stat-card`) – Kennzahlen mit Icon, Zahl und Label.
 - **Yadore Cards** (`.yadore-card`) – Standardcontainer für Einstellungen & Inhalte.
 - **Status Badges** (`.status-badge`) – Farbige Statusanzeigen, nutzen die primären Feedback-Farben.
+- **Onboarding Checklist** (`.yadore-onboarding-card`, `.checklist-item`) – Mehrstufiger Setup-Flow mit Fortschrittsanzeige, Status-Badges und kontextuellen Aktionen.
 - **Filter Pills** & **Quick Filter** – Verwenden `--yadore-radius-pill` und `--yadore-space-*` Tokens.
 
 Code-Beispiele können über den Copy-Button (Klasse `.styleguide-copy`) direkt übernommen werden. Das Snippet demonstriert ARIA-Anwendungen (`role`, `aria-labelledby`) und zeigt die erwartete Verwendung der Tokens.

--- a/languages/yadore-monetizer-de_DE.po
+++ b/languages/yadore-monetizer-de_DE.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.14\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.16\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-24T06:11:31+00:00\n"
 "PO-Revision-Date: 2025-09-24T06:11:31+00:00\n"

--- a/languages/yadore-monetizer-en_US.po
+++ b/languages/yadore-monetizer-en_US.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.14\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.16\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-24T06:11:31+00:00\n"
 "PO-Revision-Date: 2025-09-24T06:11:31+00:00\n"

--- a/languages/yadore-monetizer.pot
+++ b/languages/yadore-monetizer.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.14\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.16\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -21,6 +21,71 @@
     </div>
     <?php delete_transient('yadore_activation_notice'); endif; ?>
 
+    <?php
+    $api_connected = (bool) get_option('yadore_api_key');
+    $gemini_connected = (bool) get_option('yadore_gemini_api_key');
+    $overlay_enabled = (bool) get_option('yadore_overlay_enabled', true);
+    $auto_scan_enabled = (bool) get_option('yadore_auto_scan_posts', true);
+    $analytics_enabled = (bool) get_option('yadore_analytics_enabled', true);
+
+    $settings_url = admin_url('admin.php?page=yadore-settings');
+    $analytics_url = admin_url('admin.php?page=yadore-analytics');
+
+    $onboarding_items = array(
+        array(
+            'title' => __('Yadore-API verbinden', 'yadore-monetizer'),
+            'description' => __('Aktiviere Produktdaten, indem du deinen Yadore API-Schlüssel hinterlegst.', 'yadore-monetizer'),
+            'icon' => 'dashicons-rest-api',
+            'complete' => $api_connected,
+            'action_url' => $settings_url,
+            'action_label' => __('Einstellungen öffnen', 'yadore-monetizer'),
+        ),
+        array(
+            'title' => __('Gemini-KI konfigurieren', 'yadore-monetizer'),
+            'description' => __('Hinterlege einen Gemini API-Schlüssel, um automatische Keyword-Vorschläge zu erhalten.', 'yadore-monetizer'),
+            'icon' => 'dashicons-art',
+            'complete' => $gemini_connected,
+            'action_url' => $settings_url,
+            'action_label' => __('AI-Einstellungen prüfen', 'yadore-monetizer'),
+        ),
+        array(
+            'title' => __('Automatischen Scan aktivieren', 'yadore-monetizer'),
+            'description' => __('Lass neue Beiträge automatisch analysieren, damit immer passende Produkte erscheinen.', 'yadore-monetizer'),
+            'icon' => 'dashicons-update',
+            'complete' => $auto_scan_enabled,
+            'action_url' => $settings_url,
+            'action_label' => __('Automatisierung einschalten', 'yadore-monetizer'),
+        ),
+        array(
+            'title' => __('Overlay & Shortcode testen', 'yadore-monetizer'),
+            'description' => __('Stelle sicher, dass Overlay und Shortcode-Ausgabe für deine Inhalte aktiviert sind.', 'yadore-monetizer'),
+            'icon' => 'dashicons-visibility',
+            'complete' => $overlay_enabled,
+            'action_url' => $settings_url,
+            'action_label' => __('Darstellung konfigurieren', 'yadore-monetizer'),
+        ),
+        array(
+            'title' => __('Analytics überwachen', 'yadore-monetizer'),
+            'description' => __('Nutze das Analytics-Dashboard, um Performance und Trends im Blick zu behalten.', 'yadore-monetizer'),
+            'icon' => 'dashicons-chart-area',
+            'complete' => $analytics_enabled,
+            'action_url' => $analytics_url,
+            'action_label' => __('Analytics öffnen', 'yadore-monetizer'),
+        ),
+    );
+
+    $onboarding_total = count($onboarding_items);
+    $onboarding_completed = 0;
+    foreach ($onboarding_items as $item) {
+        if (!empty($item['complete'])) {
+            $onboarding_completed++;
+        }
+    }
+    $onboarding_progress = $onboarding_total > 0
+        ? (int) round(($onboarding_completed / $onboarding_total) * 100)
+        : 100;
+    ?>
+
     <div class="yadore-dashboard-grid">
         <!-- Main Content -->
         <div class="yadore-main-content">
@@ -252,6 +317,54 @@
 
         <!-- Sidebar -->
         <div class="yadore-sidebar">
+            <!-- Onboarding Checklist -->
+            <div class="yadore-card yadore-onboarding-card">
+                <div class="card-header">
+                    <h3><span class="dashicons dashicons-yes-alt"></span> <?php echo esc_html__('Schnellstart-Checkliste', 'yadore-monetizer'); ?></h3>
+                </div>
+                <div class="card-content">
+                    <div class="onboarding-progress" role="status" aria-live="polite">
+                        <div class="progress-summary">
+                            <span class="progress-label"><?php printf(esc_html__('%1$d von %2$d Schritten erledigt', 'yadore-monetizer'), (int) $onboarding_completed, (int) $onboarding_total); ?></span>
+                            <span class="progress-value"><?php echo esc_html($onboarding_progress); ?>%</span>
+                        </div>
+                        <div class="progress-bar" aria-hidden="true">
+                            <span class="progress-bar-fill" style="--progress: <?php echo esc_attr($onboarding_progress); ?>%;"></span>
+                        </div>
+                        <?php if ($onboarding_progress === 100) : ?>
+                            <p class="progress-message success"><?php echo esc_html__('Alle Kernfunktionen sind aktiviert – großartig!', 'yadore-monetizer'); ?></p>
+                        <?php else : ?>
+                            <p class="progress-message"><?php echo esc_html__('Folge den Schritten, um das volle Potenzial des Plugins auszuschöpfen.', 'yadore-monetizer'); ?></p>
+                        <?php endif; ?>
+                    </div>
+
+                    <div class="onboarding-checklist">
+                        <?php foreach ($onboarding_items as $item): ?>
+                            <?php $is_complete = !empty($item['complete']); ?>
+                            <div class="checklist-item <?php echo $is_complete ? 'is-complete' : 'is-pending'; ?>">
+                                <div class="checklist-icon">
+                                    <span class="dashicons <?php echo esc_attr($item['icon']); ?>" aria-hidden="true"></span>
+                                </div>
+                                <div class="checklist-content">
+                                    <strong><?php echo esc_html($item['title']); ?></strong>
+                                    <p><?php echo esc_html($item['description']); ?></p>
+                                    <div class="checklist-meta">
+                                        <span class="status-badge <?php echo $is_complete ? 'status-active' : 'status-warning'; ?>">
+                                            <?php echo esc_html($is_complete ? __('Erledigt', 'yadore-monetizer') : __('Ausstehend', 'yadore-monetizer')); ?>
+                                        </span>
+                                        <?php if (!$is_complete && !empty($item['action_url'])): ?>
+                                            <a class="button-link" href="<?php echo esc_url($item['action_url']); ?>">
+                                                <?php echo esc_html($item['action_label']); ?>
+                                            </a>
+                                        <?php endif; ?>
+                                    </div>
+                                </div>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            </div>
+
             <!-- Quick Actions -->
             <div class="yadore-card">
                 <div class="card-header">
@@ -318,18 +431,40 @@
                         </div>
 
                         <div class="status-item">
-                            <div class="status-indicator <?php echo get_option('yadore_api_key') ? 'status-active' : 'status-warning'; ?>"></div>
+                            <div class="status-indicator <?php echo $api_connected ? 'status-active' : 'status-warning'; ?>"></div>
                             <div class="status-details">
                                 <strong><?php echo esc_html__('Yadore-API', 'yadore-monetizer'); ?></strong>
-                                <small><?php echo get_option('yadore_api_key') ? esc_html__('Verbunden', 'yadore-monetizer') : esc_html__('API-Schlüssel erforderlich', 'yadore-monetizer'); ?></small>
+                                <small>
+                                    <?php
+                                    if ($api_connected) {
+                                        echo esc_html__('Verbunden', 'yadore-monetizer');
+                                    } else {
+                                        echo wp_kses_post(sprintf(
+                                            __('API-Schlüssel erforderlich – <a href="%s">jetzt verbinden</a>', 'yadore-monetizer'),
+                                            esc_url($settings_url)
+                                        ));
+                                    }
+                                    ?>
+                                </small>
                             </div>
                         </div>
 
                         <div class="status-item">
-                            <div class="status-indicator <?php echo get_option('yadore_gemini_api_key') ? 'status-active' : 'status-inactive'; ?>"></div>
+                            <div class="status-indicator <?php echo $gemini_connected ? 'status-active' : 'status-inactive'; ?>"></div>
                             <div class="status-details">
                                 <strong><?php echo esc_html__('Gemini-KI', 'yadore-monetizer'); ?></strong>
-                                <small><?php echo get_option('yadore_gemini_api_key') ? esc_html__('Verbunden', 'yadore-monetizer') : esc_html__('Nicht konfiguriert', 'yadore-monetizer'); ?></small>
+                                <small>
+                                    <?php
+                                    if ($gemini_connected) {
+                                        echo esc_html__('Verbunden', 'yadore-monetizer');
+                                    } else {
+                                        echo wp_kses_post(sprintf(
+                                            __('Nicht konfiguriert – <a href="%s">AI-Setup öffnen</a>', 'yadore-monetizer'),
+                                            esc_url($settings_url)
+                                        ));
+                                    }
+                                    ?>
+                                </small>
                             </div>
                         </div>
 

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.15
+Version: 3.16
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.15');
+define('YADORE_PLUGIN_VERSION', '3.16');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -2568,7 +2568,7 @@ HTML
 
             $this->reset_table_exists_cache();
 
-            $this->log('Enhanced database tables created successfully for v3.14', 'info');
+            $this->log('Enhanced database tables created successfully for v3.16', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Database table creation failed', $e, 'critical');


### PR DESCRIPTION
## Summary
- introduce a guided onboarding checklist with progress tracking and contextual actions on the dashboard
- surface direct setup links inside the system status card and add supporting styles for new warning badges
- bump the plugin version to 3.16 and refresh documentation plus asset headers to match the release

## Testing
- php -l templates/admin-dashboard.php
- php -l yadore-monetizer.php


------
https://chatgpt.com/codex/tasks/task_e_68e5a5c3e28883259997cb3a69829921