### PR TITLE
Align frontend colors with design tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v3.17 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v3.20 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v3.17 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v3.20 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **7 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features
@@ -15,13 +15,13 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **22 AJAX Endpoints** - Alle korrekt implementiert inkl. Produktions-Diagnostik & Cache-Tools
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 3.17**
+## 🌟 **NEU IN VERSION 3.20**
 
 - ✅ **Setup-Kommandocenter** – Ein neuer Status-Header fasst Onboarding-Fortschritt, Systemzustände und die nächste sinnvolle Aktion in einem Blick zusammen – inklusive direkter CTAs.
 - 🔄 **Live-Metriken mit Zeitstempel** – Dashboard-Kennzahlen zeigen jetzt den exakten Aktualisierungszeitpunkt mit relativer Zeitangabe, manueller Refresh-Schaltfläche und Ausfallsicherung.
 - ♿ **Verbesserte Zugänglichkeit** – Progressbars, Statusmeldungen und Shortcuts wurden mit ARIA-Labels, klaren Zuständen und Lesbarkeit für Screenreader optimiert.
 - 🧭 **Smartes Aktivitäts-Feedback** – Fehlende Daten oder Ladezustände werden mit konsistenten Hinweisen, leeren Zustandskarten und detaillierten Fehlermeldungen kommuniziert.
-- ♻️ **Version Refresh** – Alle Assets, Überschriften und Dokumentationen reflektieren die aktuelle Release-Version 3.17.
+- ♻️ **Version Refresh** – Alle Assets, Überschriften und Dokumentationen reflektieren die aktuelle Release-Version 3.20.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -67,7 +67,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v3.17:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v3.20:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -273,9 +273,9 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v3.19 - FUTURE-PROOF EXPERIENCE RELEASE!**
+## 🎉 **v3.20 - FUTURE-PROOF EXPERIENCE RELEASE!**
 
-### **Neue Highlights in v3.19:**
+### **Neue Highlights in v3.20:**
 - 🛰️ **SOTA 2025 Admin Experience** – Alle Backend-Seiten nutzen jetzt eine einheitliche Command-Bar, KPI-Hero-Header und modernisierte Glaskarten für maximale Orientierung.
 - 🎨 **Frische Design Tokens & Komponenten** – Überarbeitete Farbpaletten, Bewegungen und Schatten mit zusätzlichen Aurora-Gradients und glasigen Oberflächen.
 - ☀️ **Light-First Produktwelt** – Dunkelmodus wurde vollständig entfernt, damit Markenfarben, Tokens und Layouts konsistent in jeder Oberfläche erscheinen.
@@ -294,11 +294,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v3.19 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v3.20 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 3.19** - Production-Ready Market Release
+**Current Version: 3.20** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin-design-system.css
+++ b/assets/css/admin-design-system.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.19 - Admin Design System Tokens */
+/* Yadore Monetizer Pro v3.20 - Admin Design System Tokens */
 @layer tokens {
     :root {
         color-scheme: light;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.19 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.20 - Admin CSS (Complete) */
 @layer base {
     .yadore-admin-wrap {
         margin: 0;

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,10 @@
-/* Yadore Monetizer Pro v3.17 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v3.20 - Frontend CSS (Complete) */
+:root {
+    --yadore-frontend-color-primary-500: var(--yadore-color-primary-500, #2563eb);
+    --yadore-frontend-color-primary-600: var(--yadore-color-primary-600, #1d4ed8);
+    --yadore-frontend-color-primary-700: var(--yadore-color-primary-700, #1e40af);
+    --yadore-frontend-color-success-500: var(--yadore-color-success-500, #16a34a);
+}
 .yadore-products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -25,7 +31,7 @@
 }
 
 .yadore-product-card:focus {
-    outline: 2px solid var(--yadore-primary, #3498db);
+    outline: 2px solid var(--yadore-primary, var(--yadore-frontend-color-primary-500));
     outline-offset: 3px;
 }
 
@@ -119,14 +125,14 @@
 .price-amount {
     font-size: 24px;
     font-weight: 800;
-    color: var(--yadore-accent, #27ae60);
+    color: var(--yadore-accent, var(--yadore-frontend-color-success-500));
     letter-spacing: -0.5px;
 }
 
 .price-currency {
     font-size: 16px;
     font-weight: 600;
-    color: var(--yadore-accent, #27ae60);
+    color: var(--yadore-accent, var(--yadore-frontend-color-success-500));
 }
 
 .product-merchant {
@@ -148,7 +154,7 @@
     gap: 8px;
     width: 100%;
     padding: 14px 20px;
-    background: linear-gradient(135deg, var(--yadore-primary-light, #5dade2), var(--yadore-primary-dark, #2980b9));
+    background: linear-gradient(135deg, var(--yadore-primary-light, var(--yadore-frontend-color-primary-500)), var(--yadore-primary-dark, var(--yadore-frontend-color-primary-600)));
     color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
     border-radius: 12px;
@@ -163,7 +169,7 @@
 }
 
 .product-cta-button:hover {
-    background: linear-gradient(135deg, var(--yadore-primary-dark, #2980b9), var(--yadore-primary-darker, #21618c));
+    background: linear-gradient(135deg, var(--yadore-primary-dark, var(--yadore-frontend-color-primary-600)), var(--yadore-primary-darker, var(--yadore-frontend-color-primary-700)));
     transform: translateY(-2px);
     box-shadow: 0 6px 20px var(--yadore-primary-shadow, rgba(52, 152, 219, 0.4));
     color: var(--yadore-primary-contrast, #ffffff);
@@ -203,7 +209,7 @@
 }
 
 .yadore-product-item:focus {
-    outline: 2px solid var(--yadore-primary, #3498db);
+    outline: 2px solid var(--yadore-primary, var(--yadore-frontend-color-primary-500));
     outline-offset: 3px;
 }
 
@@ -261,7 +267,7 @@
     gap: 4px;
     font-size: 18px;
     font-weight: 700;
-    color: var(--yadore-accent, #27ae60);
+    color: var(--yadore-accent, var(--yadore-frontend-color-success-500));
 }
 
 .list-price-amount {
@@ -272,7 +278,7 @@
     display: inline-block;
     text-transform: uppercase;
     font-weight: 600;
-    color: var(--yadore-accent, #27ae60);
+    color: var(--yadore-accent, var(--yadore-frontend-color-success-500));
 }
 
 .price-currency:empty,
@@ -289,7 +295,7 @@
 
 .list-cta-button {
     padding: 10px 20px;
-    background: linear-gradient(135deg, var(--yadore-primary-light, #5dade2), var(--yadore-primary-dark, #2980b9));
+    background: linear-gradient(135deg, var(--yadore-primary-light, var(--yadore-frontend-color-primary-500)), var(--yadore-primary-dark, var(--yadore-frontend-color-primary-600)));
     color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
     border-radius: 8px;
@@ -300,7 +306,7 @@
 }
 
 .list-cta-button:hover {
-    background: linear-gradient(135deg, var(--yadore-primary-dark, #2980b9), var(--yadore-primary-darker, #21618c));
+    background: linear-gradient(135deg, var(--yadore-primary-dark, var(--yadore-frontend-color-primary-600)), var(--yadore-primary-darker, var(--yadore-frontend-color-primary-700)));
     color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
 }
@@ -365,7 +371,7 @@
 }
 
 .inline-product:focus {
-    outline: 2px solid var(--yadore-primary, #3498db);
+    outline: 2px solid var(--yadore-primary, var(--yadore-frontend-color-primary-500));
     outline-offset: 3px;
 }
 
@@ -406,7 +412,7 @@
 .inline-price {
     font-size: 16px;
     font-weight: 700;
-    color: var(--yadore-accent, #27ae60);
+    color: var(--yadore-accent, var(--yadore-frontend-color-success-500));
 }
 
 .inline-price-amount {
@@ -418,7 +424,7 @@
     margin-left: 4px;
     text-transform: uppercase;
     font-weight: 600;
-    color: var(--yadore-accent, #27ae60);
+    color: var(--yadore-accent, var(--yadore-frontend-color-success-500));
 }
 
 .inline-merchant {
@@ -430,7 +436,7 @@
 .inline-cta {
     display: inline-block;
     padding: 8px 16px;
-    background: linear-gradient(135deg, var(--yadore-primary-light, #5dade2), var(--yadore-primary-dark, #2980b9));
+    background: linear-gradient(135deg, var(--yadore-primary-light, var(--yadore-frontend-color-primary-500)), var(--yadore-primary-dark, var(--yadore-frontend-color-primary-600)));
     color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
     border-radius: 6px;
@@ -440,7 +446,7 @@
 }
 
 .inline-cta:hover {
-    background: linear-gradient(135deg, var(--yadore-primary-dark, #2980b9), var(--yadore-primary-darker, #21618c));
+    background: linear-gradient(135deg, var(--yadore-primary-dark, var(--yadore-frontend-color-primary-600)), var(--yadore-primary-darker, var(--yadore-frontend-color-primary-700)));
     color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
 }
@@ -563,7 +569,7 @@
 }
 
 .overlay-header {
-    background: linear-gradient(135deg, var(--yadore-primary-light, #5dade2) 0%, var(--yadore-primary-dark, #2980b9) 100%);
+    background: linear-gradient(135deg, var(--yadore-primary-light, var(--yadore-frontend-color-primary-500)) 0%, var(--yadore-primary-dark, var(--yadore-frontend-color-primary-600)) 100%);
     color: var(--yadore-primary-contrast, #ffffff);
     padding: 20px 24px;
     display: flex;
@@ -625,7 +631,7 @@
 
 .overlay-product:focus-within,
 .overlay-product:focus {
-    outline: 2px solid var(--yadore-primary, #3498db);
+    outline: 2px solid var(--yadore-primary, var(--yadore-frontend-color-primary-500));
     outline-offset: 3px;
 }
 
@@ -666,14 +672,14 @@
 .overlay-price-amount {
     font-size: 20px;
     font-weight: 700;
-    color: var(--yadore-accent, #27ae60);
+    color: var(--yadore-accent, var(--yadore-frontend-color-success-500));
 }
 
 .overlay-price-currency {
     font-size: 14px;
     font-weight: 600;
     margin-left: 6px;
-    color: var(--yadore-accent, #27ae60);
+    color: var(--yadore-accent, var(--yadore-frontend-color-success-500));
     text-transform: uppercase;
 }
 
@@ -687,7 +693,7 @@
     display: block;
     width: 100%;
     padding: 12px 16px;
-    background: linear-gradient(135deg, var(--yadore-primary-light, #5dade2), var(--yadore-primary-dark, #2980b9));
+    background: linear-gradient(135deg, var(--yadore-primary-light, var(--yadore-frontend-color-primary-500)), var(--yadore-primary-dark, var(--yadore-frontend-color-primary-600)));
     color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
     border-radius: 8px;
@@ -698,7 +704,7 @@
 }
 
 .overlay-product-button:hover {
-    background: linear-gradient(135deg, var(--yadore-primary-dark, #2980b9), var(--yadore-primary-darker, #21618c));
+    background: linear-gradient(135deg, var(--yadore-primary-dark, var(--yadore-frontend-color-primary-600)), var(--yadore-primary-darker, var(--yadore-frontend-color-primary-700)));
     transform: translateY(-2px);
     color: var(--yadore-primary-contrast, #ffffff);
     text-decoration: none;
@@ -744,7 +750,7 @@
     width: 32px;
     height: 32px;
     border: 3px solid var(--yadore-card-bg-muted, #f3f3f3);
-    border-top: 3px solid var(--yadore-primary, #3498db);
+    border-top: 3px solid var(--yadore-primary, var(--yadore-frontend-color-primary-500));
     border-radius: 50%;
     animation: spin 1s linear infinite;
     margin: 0 auto 16px;

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.19 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.20 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.19',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.20',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.17 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.20 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.17',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.20',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -1,6 +1,6 @@
-# Yadore Monetizer Pro Design System (v3.17)
+# Yadore Monetizer Pro Design System (v3.20)
 
-Die Admin-Oberfläche von Yadore Monetizer Pro folgt ab Version 3.16 einem token-basierten Designsystem. Seit v3.17 wurden die Status-Kommunikation, Onboarding-Hilfen und Metrik-Anzeigen weiter verfeinert. Dieses Dokument dient als zentrale Referenz für Entwickler:innen, UX-Designer:innen und QA, um konsistente UI-Entscheidungen zu treffen und Änderungen nachvollziehbar zu dokumentieren.
+Die Admin-Oberfläche von Yadore Monetizer Pro folgt ab Version 3.16 einem token-basierten Designsystem. Seit v3.20 wurden die Status-Kommunikation, Onboarding-Hilfen und Metrik-Anzeigen weiter verfeinert. Dieses Dokument dient als zentrale Referenz für Entwickler:innen, UX-Designer:innen und QA, um konsistente UI-Entscheidungen zu treffen und Änderungen nachvollziehbar zu dokumentieren.
 
 ## 1. Architektur & Dateien
 

--- a/languages/yadore-monetizer-de_DE.po
+++ b/languages/yadore-monetizer-de_DE.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.19\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.20\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-30T00:00:00+00:00\n"
 "PO-Revision-Date: 2025-09-30T00:00:00+00:00\n"

--- a/languages/yadore-monetizer-en_US.po
+++ b/languages/yadore-monetizer-en_US.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.19\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.20\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-30T00:00:00+00:00\n"
 "PO-Revision-Date: 2025-09-30T00:00:00+00:00\n"

--- a/languages/yadore-monetizer.pot
+++ b/languages/yadore-monetizer.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.19\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.20\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.19
+Version: 3.20
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.19');
+define('YADORE_PLUGIN_VERSION', '3.20');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -2581,7 +2581,7 @@ HTML
 
             $this->reset_table_exists_cache();
 
-            $this->log('Enhanced database tables created successfully for v3.17', 'info');
+            $this->log('Enhanced database tables created successfully for v3.20', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Database table creation failed', $e, 'critical');


### PR DESCRIPTION
## Summary
- replace frontend fallback hex values with design-system color tokens and add a frontend fallback token bridge
- update plugin metadata, assets, translations, and documentation to version 3.20 for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c92a22948325b4a999c95836fc2b