### PR TITLE
Align frontend status notices with design tokens

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,9 +1,15 @@
-/* Yadore Monetizer Pro v3.20 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v3.21 - Frontend CSS (Complete) */
 :root {
     --yadore-frontend-color-primary-500: var(--yadore-color-primary-500, #2563eb);
     --yadore-frontend-color-primary-600: var(--yadore-color-primary-600, #1d4ed8);
     --yadore-frontend-color-primary-700: var(--yadore-color-primary-700, #1e40af);
     --yadore-frontend-color-success-500: var(--yadore-color-success-500, #16a34a);
+    --yadore-frontend-color-warning-100: var(--yadore-color-warning-100, #fff7ed);
+    --yadore-frontend-color-warning-400: var(--yadore-color-warning-400, #fb923c);
+    --yadore-frontend-color-warning-700: var(--yadore-color-warning-700, #c2410c);
+    --yadore-frontend-color-danger-100: var(--yadore-color-danger-100, #fef2f2);
+    --yadore-frontend-color-danger-300: var(--yadore-color-danger-300, #fca5a5);
+    --yadore-frontend-color-danger-700: var(--yadore-color-danger-700, #b91c1c);
 }
 .yadore-products-grid {
     display: grid;
@@ -499,9 +505,9 @@
 /* Error States */
 .yadore-error,
 .yadore-no-results {
-    background: #fff3cd;
-    border: 1px solid #ffeaa7;
-    color: #856404;
+    background: var(--yadore-frontend-color-warning-100);
+    border: 1px solid var(--yadore-frontend-color-warning-400);
+    color: var(--yadore-frontend-color-warning-700);
     padding: 16px 20px;
     border-radius: 8px;
     margin: 20px 0;
@@ -510,9 +516,9 @@
 }
 
 .yadore-error {
-    background: #f8d7da;
-    border-color: #f5c6cb;
-    color: #721c24;
+    background: var(--yadore-frontend-color-danger-100);
+    border-color: var(--yadore-frontend-color-danger-300);
+    color: var(--yadore-frontend-color-danger-700);
 }
 
 /* Overlay Styles */

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.20
+Version: 3.21
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.20');
+define('YADORE_PLUGIN_VERSION', '3.21');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);


### PR DESCRIPTION
## Summary
- expose warning and danger color tokens for the frontend stylesheet with design-system fallbacks
- update frontend status messaging styles to reference warning and danger tokens while preserving readability
- bump the plugin version to 3.21 to reflect the styling update

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5cb6ef26c8325be5e151f73deb741