### PR TITLE
Bump plugin to v3.25 and fix dashboard actions on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v3.24 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v3.25 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v3.24 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v3.25 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **7 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features
@@ -15,12 +15,13 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **22 AJAX Endpoints** - Alle korrekt implementiert inkl. Produktions-Diagnostik & Cache-Tools
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 3.24**
+## 🌟 **NEU IN VERSION 3.25**
 
-- 🎨 **Design Consistency Audit** – Alle Status-Badges, Quick Actions, Tabellen und Diagnose-Hinweise nutzen jetzt ausschließlich die Design-Tokens für Farben, Rahmen und Hintergründe. Legacy-WordPress-Grautöne wurden entfernt, wodurch die Oberfläche sicht- und messbar konsistenter wirkt.
+- 📱 **Responsive Dashboard-Buttons** – Die Schnellaktionen im Command Center stapeln sich auf Smartphones automatisch unterhalb des Einleitungstextes. Damit bleibt der Intro-Text vollständig lesbar und keine Schaltfläche verdeckt Inhalte.
+- 🎨 **Design Consistency Audit** – Alle Status-Badges, Quick Actions, Tabellen und Diagnose-Hinweise nutzen weiterhin die Design-Tokens für Farben, Rahmen und Hintergründe. Legacy-WordPress-Grautöne bleiben entfernt, wodurch die Oberfläche sichtbar konsistent bleibt.
 - 🧭 **Konsistentes Dashboard-Meta-Layout** – Die Setup- und Integrationskacheln im Command Center nutzen ein adaptives Grid und passen sich automatisch an verfügbare Breite an. Dadurch bleiben alle Statuskarten sauber ausgerichtet und wirken nicht mehr wie eine zufällige Liste.
 - 🎛️ **Design-System Tabs & Formulare** – Die Einstellungsnavigation und Formulare greifen vollständig auf die Token-Palette zu. Farben, Abstände, Fokus- und Hover-Zustände sind damit an das Admin-Designsystem angeglichen.
-- ♻️ **Version Refresh** – Alle Assets, Überschriften und Dokumentationen reflektieren die aktuelle Release-Version 3.24.
+- ♻️ **Version Refresh** – Alle Assets, Überschriften und Dokumentationen reflektieren die aktuelle Release-Version 3.25.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -66,7 +67,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v3.24:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v3.25:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -272,9 +273,9 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v3.24 - FUTURE-PROOF EXPERIENCE RELEASE!**
+## 🎉 **v3.25 - FUTURE-PROOF EXPERIENCE RELEASE!**
 
-### **Neue Highlights in v3.24:**
+### **Neue Highlights in v3.25:**
 - 📱 **Vollständig responsive Card-Grids** – Scanner-, Analytics-, Dashboard- und Tools-Module passen sich automatisch an Viewports unter 640 px an und bleiben ohne horizontales Scrollen nutzbar.
 - 🎯 **Ausbalancierte Dashicons in Buttons** – Einheitliche 18 px Icon-Größe inklusive sauberer Flex-Ausrichtung sorgt für präzise Lesbarkeit aller Call-to-Action Buttons.
 - 🛠️ **Feinschliff im UX-Detail** – Überarbeitete Stylesheets synchronisieren Frontend- und Admin-Versionen und liefern ein konsistentes Release-Branding.
@@ -293,11 +294,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v3.24 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v3.25 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 3.24** - Production-Ready Market Release
+**Current Version: 3.25** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin-design-system.css
+++ b/assets/css/admin-design-system.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.24 - Admin Design System Tokens */
+/* Yadore Monetizer Pro v3.25 - Admin Design System Tokens */
 @layer tokens {
     :root {
         color-scheme: light;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.24 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.25 - Admin CSS (Complete) */
 @layer base {
     .yadore-admin-wrap {
         margin: 0;
@@ -309,6 +309,16 @@
 
         .yadore-hero__badge {
             margin-left: 0;
+        }
+
+        .yadore-hero__actions {
+            flex-direction: column;
+            align-items: stretch;
+        }
+
+        .yadore-hero__actions .button {
+            width: 100%;
+            justify-content: center;
         }
     }
 

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.24 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v3.25 - Frontend CSS (Complete) */
 :root {
     --yadore-frontend-color-primary-500: var(--yadore-color-primary-500, #2563eb);
     --yadore-frontend-color-primary-600: var(--yadore-color-primary-600, #1d4ed8);

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.24 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.25 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.24',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.25',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.24 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.25 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.24',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.25',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -1,6 +1,6 @@
-# Yadore Monetizer Pro Design System (v3.24)
+# Yadore Monetizer Pro Design System (v3.25)
 
-Die Admin-Oberfläche von Yadore Monetizer Pro folgt ab Version 3.16 einem token-basierten Designsystem. Mit v3.24 wurden die Hero-Metakarten, Tab-Navigation und Formulare vollständig auf die Tokenstruktur ausgerichtet. Dieses Dokument dient als zentrale Referenz für Entwickler:innen, UX-Designer:innen und QA, um konsistente UI-Entscheidungen zu treffen und Änderungen nachvollziehbar zu dokumentieren.
+Die Admin-Oberfläche von Yadore Monetizer Pro folgt ab Version 3.16 einem token-basierten Designsystem. Mit v3.25 wurden die Hero-Metakarten, Tab-Navigation und Formulare vollständig auf die Tokenstruktur ausgerichtet. Dieses Dokument dient als zentrale Referenz für Entwickler:innen, UX-Designer:innen und QA, um konsistente UI-Entscheidungen zu treffen und Änderungen nachvollziehbar zu dokumentieren.
 
 ## 1. Architektur & Dateien
 

--- a/languages/yadore-monetizer-de_DE.po
+++ b/languages/yadore-monetizer-de_DE.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.24\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.25\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-30T00:00:00+00:00\n"
 "PO-Revision-Date: 2025-09-30T00:00:00+00:00\n"

--- a/languages/yadore-monetizer-en_US.po
+++ b/languages/yadore-monetizer-en_US.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.24\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.25\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-30T00:00:00+00:00\n"
 "PO-Revision-Date: 2025-09-30T00:00:00+00:00\n"

--- a/languages/yadore-monetizer.pot
+++ b/languages/yadore-monetizer.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.24\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.25\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.24
+Version: 3.25
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.24');
+define('YADORE_PLUGIN_VERSION', '3.25');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -2581,7 +2581,7 @@ HTML
 
             $this->reset_table_exists_cache();
 
-            $this->log('Enhanced database tables created successfully for v3.24', 'info');
+            $this->log('Enhanced database tables created successfully for v3.25', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Database table creation failed', $e, 'critical');


### PR DESCRIPTION
## Summary
- bump the plugin metadata, documentation, and translation headers to version 3.25
- adjust the dashboard hero action buttons so they stack vertically on small screens instead of overlapping text

## Testing
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68e5e748bd94832596ae0566039fb09a