### PR TITLE
Fix setup status card responsive layout and bump version

### DIFF
--- a/assets/css/admin-design-system.css
+++ b/assets/css/admin-design-system.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.26 - Admin Design System Tokens */
+/* Yadore Monetizer Pro v3.27 - Admin Design System Tokens */
 @layer tokens {
     :root {
         color-scheme: light;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.26 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.27 - Admin CSS (Complete) */
 @layer base {
     .yadore-admin-wrap {
         margin: 0;
@@ -805,19 +805,6 @@
     .intro-actions {
         justify-content: stretch;
     }
-
-    .setup-status-card {
-        grid-template-columns: minmax(0, 1fr);
-    }
-
-    .setup-status-card .status-actions {
-        align-items: stretch;
-    }
-
-    .setup-status-card .status-actions .button {
-        min-width: 0;
-        width: 100%;
-    }
 }
 
 @media (max-width: 782px) {
@@ -1166,6 +1153,22 @@
 .setup-status-card .status-actions .button {
     min-width: 200px;
     justify-content: center;
+}
+
+@media (max-width: 1024px) {
+    .setup-status-card {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .setup-status-card .status-actions {
+        align-items: stretch;
+    }
+
+    .setup-status-card .status-actions .button {
+        min-width: 0;
+        width: 100%;
+        align-items: stretch;
+    }
 }
 
 .yadore-onboarding-card .card-content {

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.26 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v3.27 - Frontend CSS (Complete) */
 :root {
     --yadore-frontend-color-primary-500: var(--yadore-color-primary-500, #2563eb);
     --yadore-frontend-color-primary-600: var(--yadore-color-primary-600, #1d4ed8);

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.26 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.27 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.26',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.27',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.26 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.27 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.26',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.27',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.26
+Version: 3.27
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.26');
+define('YADORE_PLUGIN_VERSION', '3.27');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);


### PR DESCRIPTION
## Summary
- move the setup status card responsive media query after the base declarations so the single-column layout applies at ≤1024px
- ensure responsive status actions buttons stretch to full width for vertical stacking
- bump the plugin version metadata to 3.27 across core assets

## Testing
- not run (WordPress admin environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5ef98f0f48325abef02c83f0a5c57