### PR TITLE
Adjust admin button layering to override WP core

### DIFF
--- a/assets/css/admin-design-system.css
+++ b/assets/css/admin-design-system.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.27 - Admin Design System Tokens */
+/* Yadore Monetizer Pro v3.28 - Admin Design System Tokens */
 @layer tokens {
     :root {
         color-scheme: light;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.27 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.28 - Admin CSS (Complete) */
 @layer base {
     .yadore-admin-wrap {
         margin: 0;
@@ -3342,4 +3342,34 @@
     .revenue-analytics {
         grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     }
+}
+
+/* Override WordPress core button styles */
+.yadore-admin-wrap .button {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--yadore-space-2);
+    border-radius: var(--yadore-radius-pill);
+    padding-inline: calc(var(--yadore-space-3) + 2px);
+    padding-block: calc(var(--yadore-space-1-5) + 1px);
+}
+
+.yadore-admin-wrap .button .dashicons,
+.yadore-admin-wrap .button svg,
+.yadore-admin-wrap .button .yadore-button-icon {
+    margin: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    font-size: 1.125em;
+    width: 1.5em;
+    height: 1.5em;
+    flex-shrink: 0;
+}
+
+.yadore-admin-wrap .button svg {
+    width: 1.5em;
+    height: 1.5em;
+    fill: currentColor;
 }

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.27 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v3.28 - Frontend CSS (Complete) */
 :root {
     --yadore-frontend-color-primary-500: var(--yadore-color-primary-500, #2563eb);
     --yadore-frontend-color-primary-600: var(--yadore-color-primary-600, #1d4ed8);

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.27 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.28 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.27',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.28',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.27 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.28 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.27',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.28',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.27
+Version: 3.28
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.27');
+define('YADORE_PLUGIN_VERSION', '3.28');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);


### PR DESCRIPTION
## Summary
- add an unlayered override for Yadore admin buttons so they keep inline-flex alignment above WordPress core styles
- bump the plugin and asset metadata to version 3.28 per release convention

## Testing
- not run (WordPress admin UI verification requires a configured site)

------
https://chatgpt.com/codex/tasks/task_e_68e5f458e7f08325a8750e26a526218a