### PR TITLE
Improve admin input groups responsiveness and bump to v3.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v3.26 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v3.29 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v3.26 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v3.29 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **7 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features
@@ -15,13 +15,14 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **22 AJAX Endpoints** - Alle korrekt implementiert inkl. Produktions-Diagnostik & Cache-Tools
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 3.26**
+## 🌟 **NEU IN VERSION 3.29**
 
 - 📱 **Responsive Dashboard-Buttons** – Die Schnellaktionen im Command Center stapeln sich auf Smartphones automatisch unterhalb des Einleitungstextes. Damit bleibt der Intro-Text vollständig lesbar und keine Schaltfläche verdeckt Inhalte.
+- 🧾 **Mobile-optimierte Formulargruppen** – Formulareingaben und Aktionen innerhalb der Admin-Input-Gruppen stapeln sich unter 640 px automatisch und Buttons füllen die komplette Breite, wodurch Touch-Interaktionen leichter werden.
 - 🎨 **Design Consistency Audit** – Alle Status-Badges, Quick Actions, Tabellen und Diagnose-Hinweise nutzen weiterhin die Design-Tokens für Farben, Rahmen und Hintergründe. Legacy-WordPress-Grautöne bleiben entfernt, wodurch die Oberfläche sichtbar konsistent bleibt.
 - 🧭 **Konsistentes Dashboard-Meta-Layout** – Die Setup- und Integrationskacheln im Command Center nutzen ein adaptives Grid und passen sich automatisch an verfügbare Breite an. Dadurch bleiben alle Statuskarten sauber ausgerichtet und wirken nicht mehr wie eine zufällige Liste.
 - 🎛️ **Design-System Tabs & Formulare** – Die Einstellungsnavigation und Formulare greifen vollständig auf die Token-Palette zu. Farben, Abstände, Fokus- und Hover-Zustände sind damit an das Admin-Designsystem angeglichen.
-- ♻️ **Version Refresh** – Alle Assets, Überschriften und Dokumentationen reflektieren die aktuelle Release-Version 3.26.
+- ♻️ **Version Refresh** – Alle Assets, Überschriften und Dokumentationen reflektieren die aktuelle Release-Version 3.29.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -67,7 +68,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v3.26:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v3.29:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -273,9 +274,9 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v3.26 - FUTURE-PROOF EXPERIENCE RELEASE!**
+## 🎉 **v3.29 - FUTURE-PROOF EXPERIENCE RELEASE!**
 
-### **Neue Highlights in v3.26:**
+### **Neue Highlights in v3.29:**
 - 📱 **Vollständig responsive Card-Grids** – Scanner-, Analytics-, Dashboard- und Tools-Module passen sich automatisch an Viewports unter 640 px an und bleiben ohne horizontales Scrollen nutzbar.
 - 🎯 **Ausbalancierte Dashicons in Buttons** – Skalierende Icon-Größen mit sauberer Flex-Ausrichtung sorgen für präzise Lesbarkeit aller Call-to-Action Buttons.
 - 🛠️ **Feinschliff im UX-Detail** – Überarbeitete Stylesheets synchronisieren Frontend- und Admin-Versionen und liefern ein konsistentes Release-Branding.
@@ -294,11 +295,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v3.26 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v3.29 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 3.26** - Production-Ready Market Release
+**Current Version: 3.29** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin-design-system.css
+++ b/assets/css/admin-design-system.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.28 - Admin Design System Tokens */
+/* Yadore Monetizer Pro v3.29 - Admin Design System Tokens */
 @layer tokens {
     :root {
         color-scheme: light;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.28 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.29 - Admin CSS (Complete) */
 @layer base {
     .yadore-admin-wrap {
         margin: 0;
@@ -2361,6 +2361,23 @@
 
 .input-group .form-input {
     flex: 1;
+}
+
+@media (max-width: 640px) {
+    .input-group {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .input-group .form-input,
+    .input-group .button {
+        width: 100%;
+    }
+
+    .input-group .button {
+        text-align: center;
+        justify-content: center;
+    }
 }
 
 .form-row {

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.28 - Frontend CSS (Complete) */
+/* Yadore Monetizer Pro v3.29 - Frontend CSS (Complete) */
 :root {
     --yadore-frontend-color-primary-500: var(--yadore-color-primary-500, #2563eb);
     --yadore-frontend-color-primary-600: var(--yadore-color-primary-600, #1d4ed8);

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.28 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.29 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.28',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.29',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.28 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.29 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.28',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.29',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -1,6 +1,6 @@
-# Yadore Monetizer Pro Design System (v3.26)
+# Yadore Monetizer Pro Design System (v3.29)
 
-Die Admin-Oberfläche von Yadore Monetizer Pro folgt ab Version 3.16 einem token-basierten Designsystem. Mit v3.26 wurden die Hero-Metakarten, Tab-Navigation und Formulare vollständig auf die Tokenstruktur ausgerichtet. Dieses Dokument dient als zentrale Referenz für Entwickler:innen, UX-Designer:innen und QA, um konsistente UI-Entscheidungen zu treffen und Änderungen nachvollziehbar zu dokumentieren.
+Die Admin-Oberfläche von Yadore Monetizer Pro folgt ab Version 3.16 einem token-basierten Designsystem. Mit v3.29 wurden die Hero-Metakarten, Tab-Navigation und Formulare vollständig auf die Tokenstruktur ausgerichtet. Dieses Dokument dient als zentrale Referenz für Entwickler:innen, UX-Designer:innen und QA, um konsistente UI-Entscheidungen zu treffen und Änderungen nachvollziehbar zu dokumentieren.
 
 ## 1. Architektur & Dateien
 
@@ -56,6 +56,7 @@ Code-Beispiele können über den Copy-Button (Klasse `.styleguide-copy`) direkt 
 - **Spacing & Layout**: Grid-Layouts nutzen `repeat(auto-fit, minmax(...))`, um sich automatisch an verfügbare Breiten anzupassen.
 - **Typografie**: Titel verwenden `font-weight: var(--yadore-font-weight-semibold)`; Body-Text `var(--yadore-font-weight-regular)`.
 - **Fokus & Interaktionen**: Buttons und interaktive Elemente dürfen nur Tokens oder systemeigene Fokus-Stile überschreiben.
+- **Formulareingaben**: `.input-group` stapelt sich unter 640 px vertikal, dehnt Inputs und Buttons auf 100 % Breite und zentriert Button-Content für bessere Touch-Ziele.
 - **ARIA**: Komponenten, die Statusänderungen anzeigen, benötigen `aria-live` oder eindeutige Labels; das Styleguide-Template liefert Beispiele in `templates/admin-styleguide.php`.
 - **Kontraste**: Primärfarben erfüllen WCAG AA auf hellem und dunklem Hintergrund (getestet mit den hinterlegten Hex-Werten). Neue Farben müssen denselben Standard erreichen.
 

--- a/languages/yadore-monetizer-de_DE.po
+++ b/languages/yadore-monetizer-de_DE.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.26\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.29\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-30T00:00:00+00:00\n"
 "PO-Revision-Date: 2025-09-30T00:00:00+00:00\n"

--- a/languages/yadore-monetizer-en_US.po
+++ b/languages/yadore-monetizer-en_US.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.26\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.29\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-30T00:00:00+00:00\n"
 "PO-Revision-Date: 2025-09-30T00:00:00+00:00\n"

--- a/languages/yadore-monetizer.pot
+++ b/languages/yadore-monetizer.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.26\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.29\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.28
+Version: 3.29
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.28');
+define('YADORE_PLUGIN_VERSION', '3.29');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -2581,7 +2581,7 @@ HTML
 
             $this->reset_table_exists_cache();
 
-            $this->log('Enhanced database tables created successfully for v3.26', 'info');
+            $this->log('Enhanced database tables created successfully for v3.29', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Database table creation failed', $e, 'critical');


### PR DESCRIPTION
## Summary
- stack admin input groups vertically on narrow screens and center action buttons
- bump the plugin version to 3.29 across PHP constants, assets, translations, and docs
- refresh the README and styleguide with the new mobile form guidance and version info

## Testing
- php -l yadore-monetizer.php

------
https://chatgpt.com/codex/tasks/task_e_68e5faf8df8c8325aa2325d72212fa16