### PR TITLE
Align admin button heights and bump version to 3.30

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.29 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.30 - Admin CSS (Complete) */
 @layer base {
     .yadore-admin-wrap {
         margin: 0;
@@ -19,6 +19,7 @@
         border-radius: var(--yadore-radius-pill);
         padding-inline: calc(var(--yadore-space-3) + 2px);
         padding-block: calc(var(--yadore-space-1-5) + 1px);
+        min-height: 38px;
         transition: transform var(--yadore-motion-duration-medium) var(--yadore-motion-easing-emphasized),
             box-shadow var(--yadore-motion-duration-medium) var(--yadore-motion-easing-emphasized);
     }
@@ -2142,7 +2143,7 @@
 }
 
 .password-visibility-toggle .button-label {
-    line-height: 1.4;
+    line-height: inherit;
 }
 
 /* Quick Actions */
@@ -3369,6 +3370,7 @@
     border-radius: var(--yadore-radius-pill);
     padding-inline: calc(var(--yadore-space-3) + 2px);
     padding-block: calc(var(--yadore-space-1-5) + 1px);
+    min-height: 38px;
 }
 
 .yadore-admin-wrap .button .dashicons,

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.29 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.30 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.29',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.30',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.29 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.30 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.29',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.30',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.29
+Version: 3.30
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.29');
+define('YADORE_PLUGIN_VERSION', '3.30');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -2581,7 +2581,7 @@ HTML
 
             $this->reset_table_exists_cache();
 
-            $this->log('Enhanced database tables created successfully for v3.29', 'info');
+            $this->log('Enhanced database tables created successfully for v3.30', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Database table creation failed', $e, 'critical');


### PR DESCRIPTION
## Summary
- ensure admin buttons use a consistent minimum height in the admin stylesheet and inherit line height for the password toggle label
- bump the plugin version references to 3.30 in the main plugin file and JavaScript assets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6029195b0832591e81316c51786cf