### PR TITLE
Improve analytics grid responsiveness and bump version to 3.31

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.30 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.31 - Admin CSS (Complete) */
 @layer base {
     .yadore-admin-wrap {
         margin: 0;
@@ -1632,7 +1632,7 @@
     gap: 28px;
     align-items: stretch;
     margin-bottom: 32px;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
 }
 
 .overview-analytics-grid .yadore-card {
@@ -1677,7 +1677,7 @@
 
 .scanner-overview .scanner-stats {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr));
     gap: 22px;
 }
 
@@ -2896,7 +2896,7 @@
 .summary-stats {
     display: grid;
     gap: var(--yadore-space-4);
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr));
 }
 
 .performance-chart,
@@ -2928,7 +2928,7 @@
 .cloud-container {
     display: grid;
     gap: var(--yadore-space-4);
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(200px, 100%), 1fr));
 }
 
 .cloud-loading,
@@ -3034,7 +3034,7 @@
 .analytics-grid {
     display: grid;
     gap: var(--yadore-space-6);
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
 }
 
 .traffic-metrics {
@@ -3070,7 +3070,7 @@
 .conversion-funnel {
     display: grid;
     gap: var(--yadore-space-4);
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr));
 }
 
 .funnel-step {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.30 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.31 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.30',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.31',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.30 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.31 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.30',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.31',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.30
+Version: 3.31
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.30');
+define('YADORE_PLUGIN_VERSION', '3.31');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -2581,7 +2581,7 @@ HTML
 
             $this->reset_table_exists_cache();
 
-            $this->log('Enhanced database tables created successfully for v3.30', 'info');
+            $this->log('Enhanced database tables created successfully for v3.31', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Database table creation failed', $e, 'critical');


### PR DESCRIPTION
## Summary
- adjust analytics and summary grid templates to prevent cards from overflowing their containers on narrow viewports
- align related analytics layouts for consistent mobile behaviour
- bump the plugin version constants and asset headers to 3.31 for release tracking

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e60671b3b88325ac21e9a2ddb95bb8