### PR TITLE
Fix admin performance table width on small screens

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.31 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.32 - Admin CSS (Complete) */
 @layer base {
     .yadore-admin-wrap {
         margin: 0;
@@ -3128,6 +3128,7 @@
 .performance-table table,
 .keyword-performance table {
     width: 100%;
+    min-width: 680px;
     border-collapse: collapse;
     font-size: var(--yadore-font-size-sm);
 }

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.31 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.32 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.31',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.32',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.31 - Frontend JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.32 - Frontend JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global Yadore Frontend object
     window.yadoreFrontend = {
-        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.31',
+        version: (window.yadore_ajax && window.yadore_ajax.version) ? window.yadore_ajax.version : '3.32',
         settings: window.yadore_ajax || {},
         overlay: null,
         isOverlayVisible: false,

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.31
+Version: 3.32
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.31');
+define('YADORE_PLUGIN_VERSION', '3.32');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);
@@ -2581,7 +2581,7 @@ HTML
 
             $this->reset_table_exists_cache();
 
-            $this->log('Enhanced database tables created successfully for v3.31', 'info');
+            $this->log('Enhanced database tables created successfully for v3.32', 'info');
 
         } catch (Exception $e) {
             $this->log_error('Database table creation failed', $e, 'critical');


### PR DESCRIPTION
## Summary
- prevent the analytics performance tables from collapsing in the admin by enforcing a scrollable minimum width
- bump the plugin version constants and asset metadata to 3.32 to reflect the change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e607fec7f083258fe6b9157ba47609