### PR TITLE
Improve mobile admin shell spacing

### DIFF
--- a/assets/css/admin-design-system.css
+++ b/assets/css/admin-design-system.css
@@ -136,7 +136,7 @@
         --yadore-motion-easing-emphasized: cubic-bezier(0.16, 1, 0.3, 1);
 
         --yadore-container-max-width: 1280px;
-        --yadore-container-gutter: 28px;
+        --yadore-container-gutter: clamp(16px, 4vw, 28px);
     }
 
     .yadore-admin-wrap {

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.32 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.34 - Admin CSS (Complete) */
 @layer base {
     .yadore-admin-wrap {
         margin: 0;
@@ -57,12 +57,15 @@
     }
 
     .yadore-admin-shell {
-        width: min(var(--yadore-container-max-width), calc(100% - 2 * var(--yadore-container-gutter)));
+        width: 100%;
+        max-width: calc(var(--yadore-container-max-width) + 2 * var(--yadore-container-gutter));
         margin: 0 auto;
         display: flex;
         flex-direction: column;
         gap: var(--yadore-space-7);
+        padding-inline: var(--yadore-container-gutter);
         padding-bottom: var(--yadore-space-8);
+        box-sizing: border-box;
     }
 
     .yadore-admin-content {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,10 +1,10 @@
-/* Yadore Monetizer Pro v3.33 - Admin JavaScript (Complete) */
+/* Yadore Monetizer Pro v3.34 - Admin JavaScript (Complete) */
 (function($) {
     'use strict';
 
     // Global variables
     window.yadoreAdmin = {
-        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.33',
+        version: (window.yadore_admin && window.yadore_admin.version) ? window.yadore_admin.version : '3.34',
         ajax_url: yadore_admin.ajax_url,
         nonce: yadore_admin.nonce,
         debug: yadore_admin.debug || false,

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.33
+Version: 3.34
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.33');
+define('YADORE_PLUGIN_VERSION', '3.34');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);


### PR DESCRIPTION
## Summary
- make the admin shell width responsive by adding padding and a max width that respects the design gutter so cards no longer touch the viewport edge on mobile
- clamp the design token gutter for smaller screens and bump the plugin/assets metadata to version 3.34

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e612c899a8832599400c9d0fedf8bc