### PR TITLE
Improve mobile layout for scan analytics panels

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1748,6 +1748,16 @@
     color: var(--yadore-color-primary-700);
 }
 
+@media (max-width: 959px) {
+    .scan-analytics-card .analytics-grid {
+        grid-auto-rows: auto;
+    }
+
+    .scan-analytics-card .analytics-panel {
+        height: auto;
+    }
+}
+
 @media (min-width: 960px) {
     .scan-analytics-card .analytics-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.36
+Version: 3.37
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.36');
+define('YADORE_PLUGIN_VERSION', '3.37');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);


### PR DESCRIPTION
## Summary
- relax the scan analytics grid row sizing on small screens to remove excess whitespace
- ensure panels auto-size vertically on mobile and bump the plugin version to 3.37

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e62b16b78483258ed81fdc0176500c