### PR TITLE
Unify admin card spacing and bump version to 3.41

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v3.29 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v3.41 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v3.29 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v3.41 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **7 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features
@@ -15,14 +15,11 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **22 AJAX Endpoints** - Alle korrekt implementiert inkl. Produktions-Diagnostik & Cache-Tools
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
 
-## 🌟 **NEU IN VERSION 3.29**
+## 🌟 **NEU IN VERSION 3.41**
 
-- 📱 **Responsive Dashboard-Buttons** – Die Schnellaktionen im Command Center stapeln sich auf Smartphones automatisch unterhalb des Einleitungstextes. Damit bleibt der Intro-Text vollständig lesbar und keine Schaltfläche verdeckt Inhalte.
-- 🧾 **Mobile-optimierte Formulargruppen** – Formulareingaben und Aktionen innerhalb der Admin-Input-Gruppen stapeln sich unter 640 px automatisch und Buttons füllen die komplette Breite, wodurch Touch-Interaktionen leichter werden.
-- 🎨 **Design Consistency Audit** – Alle Status-Badges, Quick Actions, Tabellen und Diagnose-Hinweise nutzen weiterhin die Design-Tokens für Farben, Rahmen und Hintergründe. Legacy-WordPress-Grautöne bleiben entfernt, wodurch die Oberfläche sichtbar konsistent bleibt.
-- 🧭 **Konsistentes Dashboard-Meta-Layout** – Die Setup- und Integrationskacheln im Command Center nutzen ein adaptives Grid und passen sich automatisch an verfügbare Breite an. Dadurch bleiben alle Statuskarten sauber ausgerichtet und wirken nicht mehr wie eine zufällige Liste.
-- 🎛️ **Design-System Tabs & Formulare** – Die Einstellungsnavigation und Formulare greifen vollständig auf die Token-Palette zu. Farben, Abstände, Fokus- und Hover-Zustände sind damit an das Admin-Designsystem angeglichen.
-- ♻️ **Version Refresh** – Alle Assets, Überschriften und Dokumentationen reflektieren die aktuelle Release-Version 3.29.
+- 📦 **Vereinheitlichte Admin-Karten** – Dashboard-, Analyse- und Tool-Karten nutzen jetzt auf allen Breakpoints identische Innenabstände und eine konsistente Maximalbreite.
+- 📐 **Adaptive Card-Spacing Tokens** – Neue Clamp-basierte Token sorgen dafür, dass Header, Content und Statusbereiche derselben Karte auf Mobilgeräten genauso großzügig wirken wie auf Desktop.
+- ♻️ **Version Refresh** – Alle Assets, Überschriften und Dokumentationen reflektieren die aktuelle Release-Version 3.41.
 
 ## 🔌 **WORDPRESS INTEGRATION - 100% VOLLSTÄNDIG:**
 
@@ -68,7 +65,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v3.29:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v3.41:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -274,11 +271,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v3.29 - FUTURE-PROOF EXPERIENCE RELEASE!**
+## 🎉 **v3.41 - FUTURE-PROOF EXPERIENCE RELEASE!**
 
-### **Neue Highlights in v3.29:**
-- 📱 **Vollständig responsive Card-Grids** – Scanner-, Analytics-, Dashboard- und Tools-Module passen sich automatisch an Viewports unter 640 px an und bleiben ohne horizontales Scrollen nutzbar.
-- 🎯 **Ausbalancierte Dashicons in Buttons** – Skalierende Icon-Größen mit sauberer Flex-Ausrichtung sorgen für präzise Lesbarkeit aller Call-to-Action Buttons.
+### **Neue Highlights in v3.41:**
+- 📦 **Karten mit fixer Design-Sprache** – Einheitliche Innenabstände für Header, Content und Aktionsleisten in allen Admin-Karten.
+- 📱 **Bruchlose Breakpoints** – Clamp-gesteuerte Spacing-Tokens halten Abstände auf Smartphone, Tablet und Desktop identisch angenehm.
 - 🛠️ **Feinschliff im UX-Detail** – Überarbeitete Stylesheets synchronisieren Frontend- und Admin-Versionen und liefern ein konsistentes Release-Branding.
 
 **Alle Features sind verfügbar und voll funktional – jetzt mit Premium-UX!**
@@ -295,11 +292,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v3.29 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v3.41 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 3.29** - Production-Ready Market Release
+**Current Version: 3.41** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.40 - Admin CSS (Complete) */
+/* Yadore Monetizer Pro v3.41 - Admin CSS (Complete) */
 @layer base {
     .yadore-admin-wrap {
         margin: 0;
@@ -850,6 +850,11 @@
     flex-direction: column;
     margin-bottom: var(--yadore-space-6);
     backdrop-filter: blur(14px);
+    width: min(100%, var(--yadore-card-max-width, 100%));
+    margin-inline: auto;
+    --yadore-card-padding-inline: clamp(var(--yadore-space-4), 4vw, var(--yadore-space-6));
+    --yadore-card-padding-block: clamp(var(--yadore-space-4), 3vw, var(--yadore-space-5));
+    --yadore-card-section-gap: clamp(var(--yadore-space-4), 3.5vw, var(--yadore-space-5));
     transition: transform var(--yadore-motion-duration-medium) var(--yadore-motion-easing-emphasized),
         box-shadow var(--yadore-motion-duration-medium) var(--yadore-motion-easing-emphasized),
         border-color var(--yadore-motion-duration-medium) var(--yadore-motion-easing-standard);
@@ -878,7 +883,7 @@
 }
 
 .card-header {
-    padding: var(--yadore-space-5);
+    padding: var(--yadore-card-padding-block) var(--yadore-card-padding-inline);
     border-bottom: 1px solid rgba(15, 23, 42, 0.08);
     background: linear-gradient(135deg, rgba(37, 99, 235, 0.05), rgba(255, 255, 255, 0.92));
     display: flex;
@@ -935,15 +940,9 @@
 }
 
 .card-content {
-    padding: var(--yadore-space-5) var(--yadore-space-6);
+    padding: var(--yadore-card-padding-block) var(--yadore-card-padding-inline);
     display: grid;
-    gap: var(--yadore-space-5);
-}
-
-@media (max-width: 640px) {
-    .card-content {
-        padding: var(--yadore-space-5);
-    }
+    gap: var(--yadore-card-section-gap);
 }
 
 /* Activity List */
@@ -1056,7 +1055,7 @@
     grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: start;
     gap: var(--yadore-space-5);
-    padding: var(--yadore-space-5);
+    padding: var(--yadore-card-padding-block) var(--yadore-card-padding-inline);
     border-left: 6px solid var(--yadore-color-primary-500);
 }
 

--- a/languages/yadore-monetizer-de_DE.po
+++ b/languages/yadore-monetizer-de_DE.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.29\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.41\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-30T00:00:00+00:00\n"
 "PO-Revision-Date: 2025-09-30T00:00:00+00:00\n"

--- a/languages/yadore-monetizer-en_US.po
+++ b/languages/yadore-monetizer-en_US.po
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.29\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.41\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "POT-Creation-Date: 2025-09-30T00:00:00+00:00\n"
 "PO-Revision-Date: 2025-09-30T00:00:00+00:00\n"

--- a/languages/yadore-monetizer.pot
+++ b/languages/yadore-monetizer.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Yadore Monetizer Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Yadore Monetizer Pro 3.29\n"
+"Project-Id-Version: Yadore Monetizer Pro 3.41\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/yadore-monetizer-pro\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/yadore-monetizer.php
+++ b/yadore-monetizer.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Yadore Monetizer Pro
 Description: Professional Affiliate Marketing Plugin with Complete Feature Set
-Version: 3.40
+Version: 3.41
 Author: Matthes Vogel
 Text Domain: yadore-monetizer
 Domain Path: /languages
@@ -14,7 +14,7 @@ Network: false
 
 if (!defined('ABSPATH')) { exit; }
 
-define('YADORE_PLUGIN_VERSION', '3.40');
+define('YADORE_PLUGIN_VERSION', '3.41');
 define('YADORE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('YADORE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('YADORE_PLUGIN_FILE', __FILE__);


### PR DESCRIPTION
## Summary
- align admin card widths and padding across breakpoints with new clamp-based spacing tokens
- refresh plugin version constants, documentation, and translation headers to v3.41
- update admin CSS banner to reflect the new release

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e65e7ab19c8325b4b58480655af89e