### PR TITLE
feat: paginate translation editor and update version 3.48.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Yadore Monetizer Pro v3.48.20 - COMPLETE FEATURE SET
+# Yadore Monetizer Pro v3.48.21 - COMPLETE FEATURE SET
 
 Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY** and **ALL FEATURES INTEGRATED**.
 
-## 🚀 **YADORE MONETIZER PRO v3.48.20 - VOLLSTÄNDIGE VERSION:**
+## 🚀 **YADORE MONETIZER PRO v3.48.21 - VOLLSTÄNDIGE VERSION:**
 
 ### **🔥 ALLE FUNKTIONEN WIEDER INTEGRIERT:**
 ✅ **8 WordPress Admin Pages** - Vollständig funktional mit erweiterten Features
@@ -14,6 +14,12 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 ✅ **Data Management Tools** - Export/Import, Backup und Migration  
 ✅ **22 AJAX Endpoints** - Alle korrekt implementiert inkl. Produktions-Diagnostik & Cache-Tools
 ✅ **Enhanced Database** - 5 optimierte Tabellen mit Analytics-Support
+
+## 🌟 **NEU IN VERSION 3.48.21**
+
+- 📄 **Paginierte Übersetzungsverwaltung** – Die Translations-Seite lädt nur noch den aktuellen Ausschnitt (Standard 100 Zeilen) und zeigt Seitenlinks sowie Statistiken zu Gesamtanzahl und Limit an.
+- 🧹 **Schonendes Formular-Handling** – Beim Speichern werden gelöschte oder umbenannte Schlüssel seitenübergreifend entfernt, ohne dass Einträge anderer Seiten verloren gehen.
+- 🛠️ **Angepasste Admin-Interaktion** – Entfernen-Buttons markieren bestehende Schlüssel für die Löschung, neue Zeilen behalten ihre versteckten Originalwerte und die Paginierung bleibt nach dem Speichern erhalten.
 
 ## 🌟 **NEU IN VERSION 3.48.20**
 
@@ -77,7 +83,7 @@ Professional WordPress affiliate marketing plugin with **COMPLETE FUNCTIONALITY*
 📋 **List View** - Kompakte Listenansicht für Content-Integration  
 🔗 **Inline Display** - Nahtlose Content-Integration mit Disclaimer  
 
-## 🔧 **TECHNICAL SPECIFICATIONS - v3.48.20:**
+## 🔧 **TECHNICAL SPECIFICATIONS - v3.48.21:**
 
 ### **WordPress Environment:**
 - **WordPress Version:** 5.0+ (Getestet bis 6.4)
@@ -284,12 +290,12 @@ $settings = apply_filters('yadore_default_settings', $settings);
 
 ---
 
-## 🎉 **v3.48.20 - FUTURE-PROOF EXPERIENCE RELEASE!**
+## 🎉 **v3.48.21 - PAGINATED TRANSLATIONS RELEASE!**
 
-### **Neue Highlights in v3.48.20:**
-- 🔤 **HTML-fähige Übersetzungsschlüssel** – Inline-Markup wie `<span>` bleibt beim Speichern erhalten und kann weiterhin auf bestehende Katalogeinträge gemappt werden.
-- 🧩 **Standardkatalog-Defaults** – PHP-Sprachdateien werden automatisch eingelesen und liefern Ausgangswerte für jede Locale.
-- 💾 **Saubere Speicherung** – Unveränderte Standardtexte werden nicht mehr persistiert, wodurch nur echte Overrides bleiben.
+### **Neue Highlights in v3.48.21:**
+- 📑 **Übersichtliche Pagination** – Der Admin-Controller berechnet Seitenmetriken (`total_items`, `per_page`, `current_page`) und liefert nur den benötigten Slice an die Vorlage.
+- 🧼 **Sichere Seitenspeicherung** – `handle_translation_form()` führt Entfernen-, Umbenennen- und Merge-Operationen zusammen, sodass alle Locales auch auf späteren Seiten konsistent bleiben.
+- 🧰 **Optimierte Admin-Oberfläche** – Die Vorlage zeigt Seitenlinks, versteckte `paged`-Felder und entfernte Zeilen werden via Hidden Inputs persistiert; das JS pflegt die neuen Hooks automatisch mit ein.
 
 **Alle Features sind verfügbar und voll funktional – jetzt mit Premium-UX!**
 
@@ -305,11 +311,11 @@ $settings = apply_filters('yadore_default_settings', $settings);
 ✅ **Analytics:** ADVANCED REPORTING
 ✅ **Tools:** COMPREHENSIVE UTILITIES
 
-**Yadore Monetizer Pro v3.48.20 ist die vollständigste Version mit allen Features!** 🚀
+**Yadore Monetizer Pro v3.48.21 ist die vollständigste Version mit allen Features!** 🚀
 
 ---
 
-**Current Version: 3.48.20** - Production-Ready Market Release
+**Current Version: 3.48.21** - Production-Ready Market Release
 **Feature Status: ✅ ALL INTEGRATED**
 **WordPress Integration: ✅ 100% COMPLETE**
 **Production Status: ✅ ENTERPRISE READY**

--- a/assets/js/admin-translations.js
+++ b/assets/js/admin-translations.js
@@ -1,4 +1,4 @@
-/* Yadore Monetizer Pro v3.48.20 - Admin Translations Helper */
+/* Yadore Monetizer Pro v3.48.21 - Admin Translations Helper */
 
 (function () {
     'use strict';
@@ -16,8 +16,9 @@
         var rowsContainer = document.querySelector('#yadore-translation-rows');
         var addButton = document.querySelector('#yadore-add-translation');
         var template = document.querySelector('#yadore-translation-row-template');
+        var removedContainer = document.querySelector('#yadore-translation-removed');
 
-        if (!rowsContainer || !addButton || !template) {
+        if (!rowsContainer || !addButton || !template || !removedContainer) {
             return;
         }
 
@@ -68,13 +69,36 @@
                 return;
             }
 
+            var originalInput = row.querySelector('input[name="translation_original_keys[]"]');
+            var originalValue = originalInput && originalInput.value ? originalInput.value.trim() : '';
+
             var rows = rowsContainer.querySelectorAll('tr');
 
             if (rows.length <= 1) {
+                if (originalValue !== '') {
+                    var hidden = document.createElement('input');
+                    hidden.type = 'hidden';
+                    hidden.name = 'translation_removed_keys[]';
+                    hidden.value = originalValue;
+                    removedContainer.appendChild(hidden);
+                }
+
                 Array.prototype.forEach.call(row.querySelectorAll('input, textarea'), function (field) {
                     field.value = '';
                 });
+
+                if (originalInput) {
+                    originalInput.value = '';
+                }
                 return;
+            }
+
+            if (originalValue !== '') {
+                var removedInput = document.createElement('input');
+                removedInput.type = 'hidden';
+                removedInput.name = 'translation_removed_keys[]';
+                removedInput.value = originalValue;
+                removedContainer.appendChild(removedInput);
             }
 
             row.parentNode.removeChild(row);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 3.48.21 - 2025-12-03
+- Added pagination metadata to the translations controller and sliced entries per page to stay below `max_input_vars` limits.
+- Updated the admin translations template with pagination links, hidden paged fields, and removal markers for renamed keys.
+- Enhanced the JavaScript helper so removing rows queues hidden deletion markers and works seamlessly with paginated data.
+- Bumped plugin metadata, documentation, and asset banners to version 3.48.21.
+
 # 3.48.20 - 2025-12-02
 - Corrected the German call-to-action label for "Zum Angebot →" and synchronised the PHP and PO catalogues.
 - Bumped plugin metadata, documentation, and language headers to version 3.48.20.


### PR DESCRIPTION
## Summary
- implement paginated translation loading and saving in the controller, including per-page metadata
- update the admin translations template and helper script to render pagination controls and mark removed rows safely
- bump the plugin to version 3.48.21 and document the release in README and CHANGELOG

## Testing
- php -l yadore-monetizer.php
- php -l templates/admin-translations.php

------
https://chatgpt.com/codex/tasks/task_e_6904f601f31c83259c3bfe8a65387f2b